### PR TITLE
WIP: HTML API: Expose self-closing flag in Tag Processor

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1743,6 +1743,23 @@ class WP_HTML_Tag_Processor {
 		return strtoupper( $tag_name );
 	}
 
+	/**
+	 * Indicates if the currently matched tag contains the self-closing flag.
+	 *
+	 * No HTML elements ought to have the self-closing flag and for those, the self-closing
+	 * flag will be ignored. For void elements this is benign because they "self close"
+	 * automatically. For non-void HTML elements though problems will appear if someone
+	 * intends to use a self-closing element in place of that element with an empty body.
+	 * For HTML foreign elements and custom elements the self-closing flag determines if
+	 * they self-close or not.
+	 *
+	 * This function does not determine if a tag is self-closing,
+	 * but only if the self-closing flag is present in the syntax.
+	 *
+	 * @since 6.3.0
+	 *
+	 * @return bool Whether the currently matched tag contains the self-closing flag.
+	 */
 	public function has_self_closing_flag() {
 		if ( ! $this->tag_name_starts_at ) {
 			return false;

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1743,6 +1743,14 @@ class WP_HTML_Tag_Processor {
 		return strtoupper( $tag_name );
 	}
 
+	public function has_self_closing_flag() {
+		if ( ! $this->tag_name_starts_at ) {
+			return false;
+		}
+
+		return '/' === $this->html[ $this->tag_ends_at - 1 ];
+	}
+
 	/**
 	 * Indicates if the current tag token is a tag closer.
 	 *

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -91,6 +91,11 @@ class Tests_HtmlApi_wpHtmlTagProcessor extends WP_UnitTestCase {
 			// These can and should have self-closers, and will leave an element un-closed if it's assumed they aren't self-closing.
 			'Self-closing flag on a foreign element'    => array( '<circle />', true ),
 			'No self-closing flag on a foreign element' => array( '<circle>', false ),
+			// These involve syntax peculiarities.
+			'Self-closing flag after extra spaces'      => array( '<div      />', true ),
+			'Self-closing flag after attribute'         => array( '<div id=test/>', true ),
+			'Self-closing flag after quoted attribute'  => array( '<div id="test"/>', true ),
+			'Self-closing flag after boolean attribute' => array( '<div enabled/>', true ),
 		);
 	}
 

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -83,14 +83,14 @@ class Tests_HtmlApi_wpHtmlTagProcessor extends WP_UnitTestCase {
 			'Self-closing flag on non-void HTML element'    => array( '<div />', true ),
 			'No self-closing flag on non-void HTML element' => array( '<div>', false ),
 			// These should not have a self-closer, but are benign when used because the elements are void.
-			'Self-closing flag on void HTML element'        => array( '<img />', true ),
-			'No self-closing flag on void HTML element'     => array( '<img>', false ),
+			'Self-closing flag on void HTML element'    => array( '<img />', true ),
+			'No self-closing flag on void HTML element' => array( '<img>', false ),
 			// These should not have a self-closer, but as part of a tag closer they are entirely ignored.
-			'Self-closing flag on tag closer'               => array( '</textarea />', true ),
-			'No self-closing flag on tag closer'            => array( '</textarea>', false ),
+			'Self-closing flag on tag closer'    => array( '</textarea />', true ),
+			'No self-closing flag on tag closer' => array( '</textarea>', false ),
 			// These can and should have self-closers, and will leave an element un-closed if it's assumed they aren't self-closing.
-			'Self-closing flag on a foreign element'        => array( '<circle />', true ),
-			'No self-closing flag on a foreign element'     => array( '<circle>', false ),
+			'Self-closing flag on a foreign element'    => array( '<circle />', true ),
+			'No self-closing flag on a foreign element' => array( '<circle>', false ),
 		);
 	}
 

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -52,7 +52,7 @@ class Tests_HtmlApi_wpHtmlTagProcessor extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket NEEDS TICKET
+	 * @ticket 58009 TICKET
 	 *
 	 * @covers WP_HTML_Tag_Processor::has_self_closing_flag()
 	 *

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -72,14 +72,25 @@ class Tests_HtmlApi_wpHtmlTagProcessor extends WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * Data provider. HTML tags which might have a self-closing flag, and an indicator if they do.
+	 *
+	 * @return array[]
+	 */
 	public function data_has_self_closing_flag() {
 		return array(
-			array( '<div />', true ),
-			array( '<div>', false ),
-			array( '<img />', true ),
-			array( '<img>', false ),
-			array( '</textarea>', false ),
-			array( '</textarea />', true ),
+			// These should not have a self-closer, and will leave an element un-closed if it's assumed they are self-closing.
+			'Self-closing flag on non-void HTML element'    => array( '<div />', true ),
+			'No self-closing flag on non-void HTML element' => array( '<div>', false ),
+			// These should not have a self-closer, but are benign when used because the elements are void.
+			'Self-closing flag on void HTML element'        => array( '<img />', true ),
+			'No self-closing flag on void HTML element'     => array( '<img>', false ),
+			// These should not have a self-closer, but as part of a tag closer they are entirely ignored.
+			'Self-closing flag on tag closer'               => array( '</textarea />', true ),
+			'No self-closing flag on tag closer'            => array( '</textarea>', false ),
+			// These can and should have self-closers, and will leave an element un-closed if it's assumed they aren't self-closing.
+			'Self-closing flag on a foreign element'        => array( '<circle />', true ),
+			'No self-closing flag on a foreign element'     => array( '<circle>', false ),
 		);
 	}
 

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -80,22 +80,22 @@ class Tests_HtmlApi_wpHtmlTagProcessor extends WP_UnitTestCase {
 	public function data_has_self_closing_flag() {
 		return array(
 			// These should not have a self-closer, and will leave an element un-closed if it's assumed they are self-closing.
-			'Self-closing flag on non-void HTML element' => array( '<div />', true ),
+			'Self-closing flag on non-void HTML element'     => array( '<div />', true ),
 			'No self-closing flag on non-void HTML element' => array( '<div>', false ),
 			// These should not have a self-closer, but are benign when used because the elements are void.
 			'Self-closing flag on void HTML element' => array( '<img />', true ),
-			'No self-closing flag on void HTML element' => array( '<img>', false ),
+			'No self-closing flag on void HTML element'  => array( '<img>', false ),
 			// These should not have a self-closer, but as part of a tag closer they are entirely ignored.
 			'Self-closing flag on tag closer' => array( '</textarea />', true ),
-			'No self-closing flag on tag closer' => array( '</textarea>', false ),
+			'No self-closing flag on tag closer'         => array( '</textarea>', false ),
 			// These can and should have self-closers, and will leave an element un-closed if it's assumed they aren't self-closing.
-			'Self-closing flag on a foreign element' => array( '<circle />', true ),
-			'No self-closing flag on a foreign element' => array( '<circle>', false ),
+			'Self-closing flag on a foreign element'     => array( '<circle />', true ),
+			'No self-closing flag on a foreign element'  => array( '<circle>', false ),
 			// These involve syntax peculiarities.
-			'Self-closing flag after extra spaces' => array( '<div      />', true ),
-			'Self-closing flag after attribute' => array( '<div id=test/>', true ),
-			'Self-closing flag after quoted attribute' => array( '<div id="test"/>', true ),
-			'Self-closing flag after boolean attribute' => array( '<div enabled/>', true ),
+			'Self-closing flag after extra spaces'       => array( '<div      />', true ),
+			'Self-closing flag after attribute'          => array( '<div id=test/>', true ),
+			'Self-closing flag after quoted attribute'   => array( '<div id="test"/>', true ),
+			'Self-closing flag after boolean attribute'  => array( '<div enabled/>', true ),
 		);
 	}
 

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -52,6 +52,38 @@ class Tests_HtmlApi_wpHtmlTagProcessor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket NEEDS TICKET
+	 *
+	 * @covers WP_HTML_Tag_Processor::has_self_closing_flag()
+	 *
+	 * @dataProvider data_has_self_closing_flag
+	 *
+	 * @param string $html input HTML whose first tag might contain the self-closing flag `/`.
+	 * @param bool $flag_is_set whether the input HTML's first tag contains the self-closing flag.
+	 */
+	public function test_has_self_closing_flag_matches_input_html( $html, $flag_is_set ) {
+		$p = new WP_HTML_Tag_Processor( $html );
+		$p->next_tag( array( 'tag_closers' => 'visit' ) );
+
+		if ( $flag_is_set ) {
+			$this->assertTrue( $p->has_self_closing_flag(), 'Did not find the self-closing tag when it was present.' );
+		} else {
+			$this->assertFalse( $p->has_self_closing_flag(), 'Found the self-closing tag when it was absent.' );
+		}
+	}
+
+	public function data_has_self_closing_flag() {
+		return array(
+			array( '<div />', true ),
+			array( '<div>', false ),
+			array( '<img />', true ),
+			array( '<img>', false ),
+			array( '</textarea>', false ),
+			array( '</textarea />', true ),
+		);
+	}
+
+	/**
 	 * @ticket 56299
 	 *
 	 * @covers WP_HTML_Tag_Processor::get_attribute

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -80,21 +80,21 @@ class Tests_HtmlApi_wpHtmlTagProcessor extends WP_UnitTestCase {
 	public function data_has_self_closing_flag() {
 		return array(
 			// These should not have a self-closer, and will leave an element un-closed if it's assumed they are self-closing.
-			'Self-closing flag on non-void HTML element'    => array( '<div />', true ),
+			'Self-closing flag on non-void HTML element' => array( '<div />', true ),
 			'No self-closing flag on non-void HTML element' => array( '<div>', false ),
 			// These should not have a self-closer, but are benign when used because the elements are void.
-			'Self-closing flag on void HTML element'    => array( '<img />', true ),
+			'Self-closing flag on void HTML element' => array( '<img />', true ),
 			'No self-closing flag on void HTML element' => array( '<img>', false ),
 			// These should not have a self-closer, but as part of a tag closer they are entirely ignored.
-			'Self-closing flag on tag closer'    => array( '</textarea />', true ),
+			'Self-closing flag on tag closer' => array( '</textarea />', true ),
 			'No self-closing flag on tag closer' => array( '</textarea>', false ),
 			// These can and should have self-closers, and will leave an element un-closed if it's assumed they aren't self-closing.
-			'Self-closing flag on a foreign element'    => array( '<circle />', true ),
+			'Self-closing flag on a foreign element' => array( '<circle />', true ),
 			'No self-closing flag on a foreign element' => array( '<circle>', false ),
 			// These involve syntax peculiarities.
-			'Self-closing flag after extra spaces'      => array( '<div      />', true ),
-			'Self-closing flag after attribute'         => array( '<div id=test/>', true ),
-			'Self-closing flag after quoted attribute'  => array( '<div id="test"/>', true ),
+			'Self-closing flag after extra spaces' => array( '<div      />', true ),
+			'Self-closing flag after attribute' => array( '<div id=test/>', true ),
+			'Self-closing flag after quoted attribute' => array( '<div id="test"/>', true ),
 			'Self-closing flag after boolean attribute' => array( '<div enabled/>', true ),
 		);
 	}

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -80,13 +80,13 @@ class Tests_HtmlApi_wpHtmlTagProcessor extends WP_UnitTestCase {
 	public function data_has_self_closing_flag() {
 		return array(
 			// These should not have a self-closer, and will leave an element un-closed if it's assumed they are self-closing.
-			'Self-closing flag on non-void HTML element'     => array( '<div />', true ),
+			'Self-closing flag on non-void HTML element' => array( '<div />', true ),
 			'No self-closing flag on non-void HTML element' => array( '<div>', false ),
 			// These should not have a self-closer, but are benign when used because the elements are void.
-			'Self-closing flag on void HTML element' => array( '<img />', true ),
+			'Self-closing flag on void HTML element'     => array( '<img />', true ),
 			'No self-closing flag on void HTML element'  => array( '<img>', false ),
 			// These should not have a self-closer, but as part of a tag closer they are entirely ignored.
-			'Self-closing flag on tag closer' => array( '</textarea />', true ),
+			'Self-closing flag on tag closer'            => array( '</textarea />', true ),
 			'No self-closing flag on tag closer'         => array( '</textarea>', false ),
 			// These can and should have self-closers, and will leave an element un-closed if it's assumed they aren't self-closing.
 			'Self-closing flag on a foreign element'     => array( '<circle />', true ),


### PR DESCRIPTION
Introduces `has_self_closing_flag()` to the HTML Tag Processor, exposing whether a currently-matched tag contains the self-closing flag `/`, used when determining if one needs to look for a closing tag of the same name.

Trac ticket: _Pending_
