### PR TITLE
Gruntfile: Optimize verify:source-maps

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,7 +6,8 @@ var installChanged = require( 'install-changed' );
 var json2php = require( 'json2php' );
 
 module.exports = function(grunt) {
-	var path = require('path'),
+	var Buffer = require( 'buffer' ).Buffer,
+		path = require('path'),
 		fs = require( 'fs' ),
 		glob = require( 'glob' ),
 		assert = require( 'assert' ).strict,
@@ -1612,38 +1613,115 @@ module.exports = function(grunt) {
 	 * @ticket 24994
 	 * @ticket 46218
 	 */
-	grunt.registerTask( 'verify:source-maps', function() {
+	grunt.registerTask( 'verify:source-maps', async function() {
+		const done = this.async();
+
 		const ignoredFiles = [
 			'build/wp-includes/js/dist/components.js'
 		];
-		const files = buildFiles.reduce( ( acc, path ) => {
+
+		/** @var {string[]} File paths for files to scan for source maps. */
+		const files = [];
+
+		/** @var {Promise[]} Tracks the progress of finding files to scan. */
+		const fileSearch = [];
+
+		for ( const globPattern of buildFiles ) {
 			// Skip excluded paths and any path that isn't a file.
-			if ( '!' === path[0] || '**' !== path.substr( -2 ) ) {
-				return acc;
+			if ( '!' === globPattern[0] || ! globPattern.endsWith( '**' ) ) {
+				continue;
 			}
-			acc.push( ...glob.sync( `${ BUILD_DIR }/${ path }/*.js` ) );
-			return acc;
-		}, [] );
+
+			fileSearch.push( new Promise( ( resolve, reject ) => {
+				glob( `${ BUILD_DIR }/${ globPattern }/*.js`, ( error, matches ) => {
+					if ( null !== error ) {
+						reject();
+						return;
+					}
+
+					if ( matches.length > 0 ) {
+						files.push.apply( files, matches );
+					}
+					resolve();
+				} );
+			} ) );
+		}
+
+		await Promise.all( fileSearch );
 
 		assert(
 			files.length > 0,
 			'No JavaScript files found in the build directory.'
 		);
 
-		files
-			.filter(file => ! ignoredFiles.includes( file) )
-			.forEach( function( file ) {
-				const contents = fs.readFileSync( file, {
-					encoding: 'utf8',
-				} );
-				// `data:` URLs are allowed:
-				const match = contents.match( /sourceMappingURL=((?!data:).)/ );
+		const sourceMapSearch = [];
 
-				assert(
-					match === null,
-					`The ${ file } file must not contain a sourceMappingURL.`
-				);
-			} );
+		/** @var {Buffer} Contains source map indicator. */
+		const searchToken = Buffer.from( 'sourceMappingURL=', 'utf8' );
+		const dataUriToken = Buffer.from( 'sourceMappingURL=data:', 'utf8' );
+
+		for ( const filePath of files ) {
+			if ( ignoredFiles.includes( filePath ) ) {
+				continue;
+			}
+
+			sourceMapSearch.push( new Promise( ( resolve, reject ) => {
+				fs.open( filePath, ( error, fd ) => {
+					if ( null !== error ) {
+						reject( error );
+						return;
+					}
+
+					const BUFFER_SIZE_BYTES = 64 * 1024;
+					const START_OF_BUFFER = 0;
+					const buffer = Buffer.alloc( BUFFER_SIZE_BYTES + dataUriToken.byteLength );
+
+					/** @param {number} position Byte offset at which to start reading next chunk. */
+					const scanNextChunk = ( position ) => {
+						fs.read(
+							fd,
+							buffer,
+							START_OF_BUFFER,
+							BUFFER_SIZE_BYTES,
+							// Ensure we capture the entire search pattern in this chunk.
+							position,
+							/** @param {Buffer} chunk Next read chunk from file. */
+							( error, bytesRead, chunk ) => {
+								if ( null !== error ) {
+									reject();
+									return;
+								}
+
+								if ( bytesRead <= searchToken.byteLength ) {
+									resolve();
+									return;
+								}
+
+								const searchTokenAt = chunk.indexOf( searchToken );
+								if ( -1 === searchTokenAt ) {
+									return scanNextChunk( position + bytesRead - searchToken.byteLength );
+								}
+
+								if ( searchTokenAt + dataUriToken.byteLength + 1 > chunk.byteLength ) {
+									return scanNextChunk( searchTokenAt );
+								}
+
+								assert(
+									chunk.includes( dataUriToken ),
+									`The ${ filePath } file must not contain a sourceMappingURL.`
+								);
+								resolve();
+							}
+						);
+					};
+
+					scanNextChunk( 0 );
+				} );
+			} ) );
+		}
+
+		await Promise.all( sourceMapSearch );
+		done();
 	} );
 
 	grunt.registerTask( 'build', function() {


### PR DESCRIPTION
The `verify:source-maps` check runs serially both to find the set of files to check as well as to scan those files. Additionally, it loads the entire contents of those files into memory when running and then performs a full text search across the contents in memory.

In this patch we're refactoring that check to run asynchronously. It concurrently calls the `glob` function to search for the files to scan, and then concurrently scans those files files one 64 KB chunk at a time to look for the source map text.

This concurrency should eliminate some IO bottlenecking and the chunking might drop the memory use if the previously loaded files are large enough. Now, memory use should correspond to roughly 64 KB times the number of concurrently opened files that are being scanned.

---

Interestingly, with `N = 20`, there's no meaningful change in performance, and the script executes too fast for me to watch the CPU core activity.

```bash
# on darwin
/usr/bin/time -l npx grunk verify:source-maps
```

Mean values.

| Measure | `trunk` | this branch | change |
|---|---|---|---|
| maximum resident set size | 210848972.8 | 219451392 | +4.08% |
| peak memory footprint | 2157075.2 | 2137411.2 | -0.92% |
| cycles elapsed | 18917476.15 | 19269419.5 | +1.86% |
| page reclaims | 17786.4 | 18309.1 | +2.94% |
| voluntary context switches | 9.15 | 9.1 | |
| involuntary context switches | 1360 | 5851.4 | |

The user/system/real times didn't show any noticeable change either, which is likely because the runtime is dominated by `grunt` bootup time. This may be the same cause for the other metrics appearing unchanged.

The involuntary context switches surging in this branch are probably the result of the IO concurrency switching tasks while waiting on file IO.
