### PR TITLE
HTML API: Add set/get inner/outer functions

### DIFF
--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2540,20 +2540,20 @@ function compression_test() {
  *
  * @see get_submit_button()
  *
- * @param string       $text             Optional. The text of the button. Defaults to 'Save Changes'.
+ * @param string       $text             The text of the button (defaults to 'Save Changes')
  * @param string       $type             Optional. The type and CSS class(es) of the button. Core values
  *                                       include 'primary', 'small', and 'large'. Default 'primary'.
- * @param string       $name             Optional. The HTML name of the submit button. If no `id` attribute
- *                                       is given in the `$other_attributes` parameter, `$name` will be used
- *                                       as the button's `id`. Default 'submit'.
- * @param bool         $wrap             Optional. True if the output button should be wrapped in a paragraph tag,
- *                                       false otherwise. Default true.
- * @param array|string $other_attributes Optional. Other attributes that should be output with the button,
- *                                       mapping attributes to their values, e.g. `array( 'id' => 'search-submit' )`.
- *                                       These key/value attribute pairs will be output as `attribute="value"`,
- *                                       where attribute is the key. Attributes can also be provided as a string,
- *                                       e.g. `id="search-submit"`, though the array format is generally preferred.
- *                                       Default null.
+ * @param string       $name             The HTML name of the submit button. Defaults to "submit". If no
+ *                                       id attribute is given in $other_attributes below, $name will be
+ *                                       used as the button's id.
+ * @param bool         $wrap             True if the output button should be wrapped in a paragraph tag,
+ *                                       false otherwise. Defaults to true.
+ * @param array|string $other_attributes Other attributes that should be output with the button, mapping
+ *                                       attributes to their values, such as setting tabindex to 1, etc.
+ *                                       These key/value attribute pairs will be output as attribute="value",
+ *                                       where attribute is the key. Other attributes can also be provided
+ *                                       as a string such as 'tabindex="1"', though the array format is
+ *                                       preferred. Default null.
  */
 function submit_button( $text = null, $type = 'primary', $name = 'submit', $wrap = true, $other_attributes = null ) {
 	echo get_submit_button( $text, $type, $name, $wrap, $other_attributes );
@@ -2564,20 +2564,20 @@ function submit_button( $text = null, $type = 'primary', $name = 'submit', $wrap
  *
  * @since 3.1.0
  *
- * @param string       $text             Optional. The text of the button. Defaults to 'Save Changes'.
+ * @param string       $text             Optional. The text of the button. Default 'Save Changes'.
  * @param string       $type             Optional. The type and CSS class(es) of the button. Core values
  *                                       include 'primary', 'small', and 'large'. Default 'primary large'.
- * @param string       $name             Optional. The HTML name of the submit button. If no `id` attribute
- *                                       is given in the `$other_attributes` parameter, `$name` will be used
- *                                       as the button's `id`. Default 'submit'.
- * @param bool         $wrap             Optional. True if the output button should be wrapped in a paragraph tag,
- *                                       false otherwise. Default true.
+ * @param string       $name             Optional. The HTML name of the submit button. Defaults to "submit".
+ *                                       If no id attribute is given in $other_attributes below, `$name` will
+ *                                       be used as the button's id. Default 'submit'.
+ * @param bool         $wrap             Optional. True if the output button should be wrapped in a paragraph
+ *                                       tag, false otherwise. Default true.
  * @param array|string $other_attributes Optional. Other attributes that should be output with the button,
- *                                       mapping attributes to their values, e.g. `array( 'id' => 'search-submit' )`.
- *                                       These key/value attribute pairs will be output as `attribute="value"`,
- *                                       where attribute is the key. Attributes can also be provided as a string,
- *                                       e.g. `id="search-submit"`, though the array format is generally preferred.
- *                                       Default empty string.
+ *                                       mapping attributes to their values, such as `array( 'tabindex' => '1' )`.
+ *                                       These attributes will be output as `attribute="value"`, such as
+ *                                       `tabindex="1"`. Other attributes can also be provided as a string such
+ *                                       as `tabindex="1"`, though the array format is typically cleaner.
+ *                                       Default empty.
  * @return string Submit button HTML.
  */
 function get_submit_button( $text = '', $type = 'primary large', $name = 'submit', $wrap = true, $other_attributes = '' ) {

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -1016,7 +1016,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		foreach ( $this->state->stack_of_open_elements->with_pop_listener( $tag_is_closed ) as $_ ) {
 			// Find where the tag is closed by stepping forward until it's no longer on the stack of open elements.
 			do {
-				$found_tag       = $this->step();
+				$found_tag = $this->step();
 			} while ( $found_tag && $keep_searching );
 		}
 

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1584,7 +1584,7 @@ class WP_HTML_Tag_Processor {
 	 * @param int $shift_this_point Accumulate and return shift for this position.
 	 * @return int How many bytes the given pointer moved in response to the updates.
 	 */
-	private function apply_attributes_updates( $shift_this_point = 0 ) {
+	protected function apply_attributes_updates( $shift_this_point = 0 ) {
 		if ( ! count( $this->lexical_updates ) ) {
 			return 0;
 		}

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor.php
@@ -91,8 +91,6 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 	 *
 	 * @covers WP_HTML_Processor::next_tag
 	 * @covers WP_HTML_Processor::seek
-	 *
-	 * @throws WP_HTML_Unsupported_Exception
 	 */
 	public function test_clear_to_navigate_after_seeking() {
 		$p = WP_HTML_Processor::create_fragment( '<div one><strong></strong></div><p><strong two></strong></p>' );

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorGetInnerMarkup.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorGetInnerMarkup.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Unit tests covering WP_HTML_Processor::get_raw_inner_markup()
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ *
+ * @since 6.4.0
+ *
+ * @group html-api
+ *
+ * @coversDefaultClass WP_HTML_Processor
+ */
+class Tests_HtmlApi_WpHtmlProcessorGetInnerMarkup extends WP_UnitTestCase {
+	/**
+	 * @ticket {TICKET_NUMBER}
+	 *
+	 * @covers WP_HTML_Processor::get_raw_inner_markup
+	 *
+	 * @since 6.4.0
+	 */
+	public function test_returns_null_when_not_on_a_matching_tag() {
+		$p = WP_HTML_Processor::createFragment( '<p><div><span></span></div>' );
+
+		$this->assertNull( $p->get_raw_inner_markup() );
+
+		$this->assertFalse( $p->next_tag( 'BUTTON' ), "Should not have found a BUTTON tag but stopped at {$p->get_tag()}." );
+		$this->assertNull( $p->get_raw_inner_markup() );
+	}
+
+	/**
+	 * @ticket {TICKET_NUMBER}
+	 *
+	 * @covers WP_HTML_Processor::get_raw_inner_markup
+	 *
+	 * @dataProvider data_html_with_inner_markup
+	 *
+	 * @since 6.4.0
+	 *
+	 * @param string $html_with_target_node HTML containing a node with the `target` attribute set.
+	 * @param string $expected_inner_markup Inner markup of target node.
+	 */
+	public function test_returns_appropriate_inner_markup( $html_with_target_node, $expected_inner_markup ) {
+		$p = WP_HTML_Processor::createFragment( $html_with_target_node );
+
+		while ( $p->next_tag() && null === $p->get_attribute( 'target' ) ) {
+			continue;
+		}
+
+		$this->assertSame( $expected_inner_markup, $p->get_raw_inner_markup(), 'Failed to return appropriate inner markup.' );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_html_with_inner_markup() {
+		$data = array(
+			'Void elements'                => array( '<img target>', '' ),
+			'Empty elements'               => array( '<div target></div>', '' ),
+			'Element containing only text' => array( '<div target>inside</div>', 'inside' ),
+			'Element with nested tags'     => array( '<div target>inside <span>the</span> div</div>', 'inside <span>the</span> div' ),
+			'Unclosed element'             => array( '<div target>This is <em>all</em> inside the DIV', 'This is <em>all</em> inside the DIV' ),
+			'Unclosed elements'            => array( '<div><div target>Inside <em>P</em> <i>tags</div>', 'Inside <em>P</em> <i>tags' ),
+			'Partially-closed element'     => array( '<div target>This is <em>all</em> inside the DIV</div', 'This is <em>all</em> inside the DIV</div' ),
+			'Implicitly-closed element'    => array( '<div><p target>Inside the P</div>Outside the P</p>', 'Inside the P' ),
+		);
+
+		$inner_html = <<<HTML
+			<p>This is inside the <strong>Match</strong></p>
+			<p><img></p>
+			<div>
+				<figure>
+					<img>
+					<figcaption>Look at the <strike>picture</strike> photograph.</figcaption>
+				</figure>
+			</div>
+HTML;
+
+		$html = <<<HTML
+			<div>
+				 <p>This is not in the match.
+				 <p>This is another paragraph not <a href="#">in</a> the match.
+			</div>
+			<div target>{$inner_html}</div>
+			<div>
+				 <p>This is also note in the match.</p>
+			</div>
+HTML;
+
+		$data['Complicated inner nesting'] = array( $html, $inner_html );
+
+		return $data;
+	}
+
+	/**
+	 * Ensures that the cursor isn't moved when getting the inner markup.
+	 * It should remain at the tag opener from where it was called.
+	 *
+	 * @ticket {TICKET_NUMBER}
+	 *
+	 * @covers WP_HTML_Processor::get_raw_inner_markup
+	 *
+	 * @since 6.4.0
+	 */
+	public function test_preserves_cursor() {
+		$p = WP_HTML_Processor::createFragment( '<div><p><span target>The <code inner-target>cursor</code> should not move <em>unexpectedly</em>.</span></p></div>' );
+
+		while ( $p->next_tag() && null === $p->get_attribute( 'target' ) ) {
+			continue;
+		}
+
+		$this->assertSame(
+			'The <code inner-target>cursor</code> should not move <em>unexpectedly</em>.',
+			$p->get_raw_inner_markup(),
+			'Failed to return appropriate inner markup.'
+		);
+
+		$this->assertSame( 'SPAN', $p->get_tag(), "Should have remained on SPAN, but found {$p->get_tag()} instead." );
+		$this->assertFalse( $p->is_tag_closer(), 'Should have remained on SPAN opening tag, but stopped at closing tag instead.' );
+
+		$p->next_tag();
+		$this->assertNotNull( $p->get_attribute( 'inner-target' ), "Expected to move to inner CODE element, but found {$p->get_tag()} instead." );
+	}
+}

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorGetOuterMarkup.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorGetOuterMarkup.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Unit tests covering WP_HTML_Processor::get_raw_outer_markup()
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ *
+ * @since 6.4.0
+ *
+ * @group html-api
+ *
+ * @coversDefaultClass WP_HTML_Processor
+ */
+class Tests_HtmlApi_WpHtmlProcessorGetOuterMarkup extends WP_UnitTestCase {
+	/**
+	 * Ensures that it's not possible to get inner contents when not stopped at a tag in the HTML.
+	 *
+	 * @ticket {TICKET_NUMBER}
+	 *
+	 * @covers WP_HTML_Processor::get_raw_outer_markup
+	 *
+	 * @since 6.4.0
+	 */
+	public function test_returns_null_when_not_on_a_matching_tag() {
+		$p = WP_HTML_Processor::createFragment( '<p><div><span></span></div>' );
+
+		$this->assertNull( $p->get_raw_outer_markup() );
+
+		$this->assertFalse( $p->next_tag( 'BUTTON' ), "Should not have found a BUTTON tag but stopped at {$p->get_tag()}." );
+		$this->assertNull( $p->get_raw_outer_markup() );
+	}
+
+	/**
+	 * @ticket {TICKET_NUMBER}
+	 *
+	 * @covers WP_HTML_Processor::get_raw_outer_markup
+	 *
+	 * @dataProvider data_html_with_outer_markup
+	 *
+	 * @since 6.4.0
+	 *
+	 * @param string $html_with_target_node HTML containing a node with the `target` attribute set.
+	 * @param string $expected_outer_markup Outer markup of target node.
+	 */
+	public function test_returns_appropriate_outer_markup( $html_with_target_node, $expected_outer_markup ) {
+		$p = WP_HTML_Processor::createFragment( $html_with_target_node );
+
+		while ( $p->next_tag() && null === $p->get_attribute( 'target' ) ) {
+			continue;
+		}
+
+		$this->assertSame( $expected_outer_markup, $p->get_raw_outer_markup(), 'Failed to return appropriate outer markup.' );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_html_with_outer_markup() {
+		$data = array(
+			'Void elements'                => array( '<img target>', '<img target>' ),
+			'Empty elements'               => array( '<div target></div>', '<div target></div>' ),
+			'Element containing only text' => array( '<div target>inside</div>', '<div target>inside</div>' ),
+			'Element with nested tags'     => array( '<div target>inside <span>the</span> div</div>', '<div target>inside <span>the</span> div</div>' ),
+			'Unclosed element'             => array( '<div target>This is <em>all</em> inside the DIV', '<div target>This is <em>all</em> inside the DIV' ),
+			'Unclosed elements'            => array( '<div><p target>Inside <em>P</em> <i>tags</div>', '<p target>Inside <em>P</em> <i>tags' ),
+			'Partially-closed element'     => array( '<div target>This is <em>all</em> inside the DIV</div', '<div target>This is <em>all</em> inside the DIV</div' ),
+			'Implicitly-closed element'    => array( '<div><p target>Inside the P</div>Outside the P</p>', '<p target>Inside the P' ),
+		);
+
+		$inner_html = <<<HTML
+			<p>This is inside the <strong>Match</strong></p>
+			<p><img></p>
+			<div>
+				<figure>
+					<img>
+					<figcaption>Look at the <strike>picture</strike> photograph.</figcaption>
+				</figure>
+			</div>
+HTML;
+
+		$html = <<<HTML
+			<div>
+				<p>This is not in the match.
+				<p>This is another paragraph not <a href="#">in</a> the match.
+			</div>
+			<div target>{$inner_html}</div>
+			<div>
+				<p>This is also note in the match.</p>
+			</div>
+HTML;
+
+		$data['Complicated inner nesting'] = array( $html, "<div target>{$inner_html}</div>" );
+
+		return $data;
+	}
+
+	/**
+	 * Ensures that the cursor isn't moved when getting the outer markup.
+	 * It should remain at the tag opener from where it was called.
+	 *
+	 * @ticket {TICKET_NUMBER}
+	 *
+	 * @covers WP_HTML_Processor::get_raw_outer_markup
+	 *
+	 * @since 6.4.0
+	 */
+	public function test_preserves_cursor() {
+		$p = WP_HTML_Processor::createFragment( '<div><p><span target>The <code inner-target>cursor</code> should not move <em>unexpectedly</em>.</span></p></div>' );
+
+		while ( $p->next_tag() && null === $p->get_attribute( 'target' ) ) {
+			continue;
+		}
+
+		$this->assertSame(
+			'<span target>The <code inner-target>cursor</code> should not move <em>unexpectedly</em>.</span>',
+			$p->get_raw_outer_markup(),
+			'Failed to return appropriate outer markup.'
+		);
+
+		$this->assertSame( 'SPAN', $p->get_tag(), "Should have remained on SPAN, but found {$p->get_tag()} instead." );
+		$this->assertFalse( $p->is_tag_closer(), 'Should have remained on SPAN opening tag, but stopped at closing tag instead.' );
+
+		$p->next_tag();
+		$this->assertNotNull( $p->get_attribute( 'inner-target' ), "Expected to move to inner CODE element, but found {$p->get_tag()} instead." );
+	}
+}

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorSetInnerMarkup.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorSetInnerMarkup.php
@@ -53,6 +53,14 @@ class Tests_HtmlApi_WpHtmlProcessorSetInnerMarkup extends WP_UnitTestCase {
 			'Unclosed nested element'             => array( '<div><p target>One thought<p>And another', '', '<div><p target><p>And another' ),
 			'Partially-closed element'            => array( '<div target>This is <em>all</em> inside the DIV</div', '', '<div target>' ),
 			'Implicitly-closed element'           => array( '<div><p target>Inside the P</div>Outside the P</p>', '', '<div><p target></div>Outside the P</p>' ),
+
+			'Text markup'                         => array( '<span target></span>', 'Today is the best day to start.', '<span target>Today is the best day to start.</span>' ),
+			'Text with ampersand (raw)'           => array( '<span target></span>', 'Today & yesterday are the best days to start.', '<span target>Today & yesterday are the best days to start.</span>' ),
+			'Text with tag (raw)'                 => array( '<span target></span>', 'Yesterday <em>was</em> the best day to start.', '<span target>Yesterday <em>was</em> the best day to start.</span>' ),
+			'Text with unclosed tag (raw)'        => array( '<span target></span>', 'Yesterday <em>was the best day to start.', '<span target>Yesterday <em>was the best day to start.</span>' ),
+			'Text with ending tag (raw)'          => array( '<span target></span>', 'Here is no </div>', '<span target>Here is no </div></span>' ),
+			'Text with scope-creating tag (raw)'  => array( '<span target></span>', '<p>Start<p>Finish<p>Repeat', '<span target><p>Start<p>Finish<p>Repeat</span>' ),
+			'Text with scope-ending tag (raw)'    => array( '<span target></span>', 'Sneaky closing </span> No more span.', '<span target>Sneaky closing </span> No more span.</span>' ),
 		);
 
 		$inner_html = <<<HTML

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorSetInnerMarkup.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorSetInnerMarkup.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Unit tests covering WP_HTML_Processor::set_raw_inner_markup()
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ *
+ * @since 6.4.0
+ *
+ * @group html-api
+ *
+ * @coversDefaultClass WP_HTML_Processor
+ */
+class Tests_HtmlApi_WpHtmlProcessorSetInnerMarkup extends WP_UnitTestCase {
+	/**
+	 * @ticket {TICKET_NUMBER}
+	 *
+	 * @covers WP_HTML_Processor::set_raw_inner_markup
+	 *
+	 * @dataProvider data_html_with_inner_markup_changes
+	 *
+	 * @since 6.4.0
+	 *
+	 * @param string $html_with_target_node HTML containing a node with the `target` attribute set.
+	 * @param string $new_markup            HTML for replacing the inner markup of the target node.
+	 * @param string $expected_output       New HTMl after replacing inner markup.
+	 */
+	public function test_replaces_inner_html_appropriately( $html_with_target_node, $new_markup, $expected_output ) {
+		$p = WP_HTML_Processor::createFragment( $html_with_target_node );
+
+		while ( $p->next_tag() && null === $p->get_attribute( 'target' ) ) {
+			continue;
+		}
+
+		$this->assertTrue( $p->set_raw_inner_markup( $new_markup ), 'Failed to set inner markup.' );
+		$this->assertSame( $expected_output, $p->get_updated_html(), 'Failed to appropriately set inner markup.' );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_html_with_inner_markup_changes() {
+		$data = array(
+			'Void element'                        => array( '<img target>', '', '<img target>' ),
+			'Void element inside text'            => array( 'before<img src="atat.png" loading=lazy target>after', '', 'before<img src="atat.png" loading=lazy target>after' ),
+			'Void element inside another element' => array( '<p>Look at this <img target> graph.</p>', '', '<p>Look at this <img target> graph.</p>' ),
+			'Empty elements'                      => array( '<div target></div>', '', '<div target></div>' ),
+			'Element with nested tags'            => array( '<div target>inside <span>the</span> div</div>', '', '<div target></div>' ),
+			'Element inside another element'      => array( '<div>inside <span target>the</span> div</div>', '', '<div>inside <span target></span> div</div>' ),
+			'Unclosed element'                    => array( '<div target>This is <em>all</em> inside the DIV', '', '<div target>' ),
+			'Unclosed nested element'             => array( '<div><p target>One thought<p>And another', '', '<div><p target><p>And another' ),
+			'Partially-closed element'            => array( '<div target>This is <em>all</em> inside the DIV</div', '', '<div target>' ),
+			'Implicitly-closed element'           => array( '<div><p target>Inside the P</div>Outside the P</p>', '', '<div><p target></div>Outside the P</p>' ),
+		);
+
+		$inner_html = <<<HTML
+			<p>This is inside the <strong>Match</strong></p>
+			<p><img></p>
+			<div>
+				  <figure>
+					   <img>
+					   <figcaption>Look at the <strike>picture</strike> photograph.</figcaption>
+				  </figure>
+			</div>
+HTML;
+
+		$prefix = <<<HTML
+			<div>
+				<p>This is not in the match.
+				<p>This is another paragraph not <a href="#">in</a> the match.
+			</div>
+			<div target>
+HTML;
+
+		/*
+		 * Removing the indent on this first line keeps the test easy to reason about,
+		 * otherwise extra indents appear after removing the inner content, because
+		 * that indentation before and after is whitespace and not part of the tag.
+		 */
+		$suffix = <<<HTML
+</div>
+			<div>
+				<p>This is also note in the match.</p>
+			</div>
+HTML;
+
+		$data['Complicated inner nesting'] = array( $prefix . $inner_html . $suffix, '', $prefix . $suffix );
+
+		return $data;
+	}
+
+	/**
+	 * Ensures that the cursor isn't moved when setting the inner markup. It should
+	 * remain at the same location as the tag opener where it was called.
+	 *
+	 * @ticket {TICKET_NUMBER}
+	 *
+	 * @covers WP_HTML_Processor::set_raw_inner_markup
+	 *
+	 * @since 6.4.0
+	 */
+	public function test_preserves_cursor() {
+		$p = WP_HTML_Processor::createFragment( '<div><p><span>The <code target>cursor</code> should not move <em next-target>unexpectedly</em>.</span></p></div>' );
+
+		while ( $p->next_tag() && null === $p->get_attribute( 'target' ) ) {
+			continue;
+		}
+
+		$this->assertTrue( $p->set_raw_inner_markup( '<img next-target>' ) );
+		$this->assertSame(
+			'<div><p><span>The <code target><img next-target></code> should not move <em next-target>unexpectedly</em>.</span></p></div>',
+			$p->get_updated_html(),
+			'Failed to replace appropriate inner markup.'
+		);
+
+		$this->assertSame( 'CODE', $p->get_tag(), "Should have remained on CODE, but found {$p->get_tag()} instead." );
+
+		$p->next_tag();
+		$this->assertNotNull( $p->get_attribute( 'next-target' ), "Expected to move to inserted IMG element, but found {$p->get_tag()} instead." );
+	}
+}

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorSetOuterMarkup.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorSetOuterMarkup.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Unit tests covering WP_HTML_Processor::set_raw_outer_markup()
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ *
+ * @since 6.4.0
+ *
+ * @group html-api
+ *
+ * @coversDefaultClass WP_HTML_Processor
+ */
+class Tests_HtmlApi_WpHtmlProcessorSetOuterMarkup extends WP_UnitTestCase {
+	/**
+	 * @ticket {TICKET_NUMBER}
+	 *
+	 * @covers WP_HTML_Processor::set_raw_outer_markup
+	 *
+	 * @dataProvider data_html_with_outer_markup_changes
+	 *
+	 * @since 6.4.0
+	 *
+	 * @param string $html_with_target_node HTML containing a node with the `target` attribute set.
+	 * @param string $new_markup            HTML for replacing the outer markup of the target node.
+	 * @param string $expected_output       New HTMl after replacing outer markup.
+	 */
+	public function test_replaces_outer_html_appropriately( $html_with_target_node, $new_markup, $expected_output ) {
+		$p = WP_HTML_Processor::createFragment( $html_with_target_node );
+
+		while ( $p->next_tag() && null === $p->get_attribute( 'target' ) ) {
+			continue;
+		}
+
+		$this->assertTrue( $p->set_raw_outer_markup( $new_markup ), 'Failed to set outer markup.' );
+		$this->assertSame( $expected_output, $p->get_updated_html(), 'Failed to appropriately set outer markup.' );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_html_with_outer_markup_changes() {
+		$data = array(
+			'Void element'                        => array( '<img target>', '', '' ),
+			'Void element inside text'            => array( 'before<img src="atat.png" loading=lazy target>after', '', 'beforeafter' ),
+			'Void element inside another element' => array( '<p>Look at this <img target> graph.</p>', '', '<p>Look at this  graph.</p>' ),
+			'Empty elements'                      => array( '<div target></div>', '', '' ),
+			'Element with nested tags'            => array( '<div target>inside <span>the</span> div</div>', '', '' ),
+			'Element inside another element'      => array( '<div>inside <span target>the</span> div</div>', '', '<div>inside  div</div>' ),
+			'Unclosed element'                    => array( '<div target>This is <em>all</em> inside the DIV', '', '' ),
+			'Unclosed nested element'             => array( '<div><p target>One thought<p>And another', '', '<div><p>And another' ),
+			'Partially-closed element'            => array( '<div target>This is <em>all</em> inside the DIV</div', '', '' ),
+			'Implicitly-closed element'           => array( '<div><p target>Inside the P</div>Outside the P</p>', '', '<div></div>Outside the P</p>' ),
+		);
+
+		/*
+		 * Removing the indent on this variable keeps the test easy to reason about,
+		 * otherwise extra indents appear after removing the inner content, because
+		 * that indentation before and after is whitespace and not part of the tag.
+		 */
+		$inner_html = <<<HTML
+<div target>
+	<p>This is inside the <strong>Match</strong></p>
+	<p><img></p>
+	<div>
+		  <figure>
+			   <img>
+			   <figcaption>Look at the <strike>picture</strike> photograph.</figcaption>
+		  </figure>
+	</div>
+</div>
+HTML;
+
+		$prefix = <<<HTML
+			<div>
+				<p>This is not in the match.
+				<p>This is another paragraph not <a href="#">in</a> the match.
+			</div>
+HTML;
+
+		$suffix = <<<HTML
+			<div>
+				<p>This is also note in the match.</p>
+			</div>
+HTML;
+
+		$data['Complicated inner nesting'] = array( $prefix . $inner_html . $suffix, '', $prefix . $suffix );
+
+		return $data;
+	}
+
+	/**
+	 * Ensures that the cursor isn't moved when setting the outer markup. It should
+	 * remain at the same location as the tag opener where it was called.
+	 *
+	 * @ticket {TICKET_NUMBER}
+	 *
+	 * @covers WP_HTML_Processor::set_raw_outer_markup
+	 *
+	 * @since 6.4.0
+	 */
+	public function test_preserves_cursor() {
+		$p = WP_HTML_Processor::createFragment( '<div><p><span>The <code target>cursor</code> should not move <em next-target>unexpectedly</em>.</span></p></div>' );
+
+		while ( $p->next_tag() && null === $p->get_attribute( 'target' ) ) {
+			continue;
+		}
+
+		$this->assertTrue( $p->set_raw_outer_markup( '<img>' ) );
+		$this->assertSame(
+			'<div><p><span>The <img> should not move <em next-target>unexpectedly</em>.</span></p></div>',
+			$p->get_updated_html(),
+			'Failed to replace appropriate outer markup.'
+		);
+
+		$this->assertSame( 'IMG', $p->get_tag(), "Should have remained on IMG, but found {$p->get_tag()} instead." );
+
+		$p->next_tag();
+		$this->assertNotNull( $p->get_attribute( 'next-target' ), "Expected to move to following EM element, but found {$p->get_tag()} instead." );
+	}
+}

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorSetOuterMarkup.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorSetOuterMarkup.php
@@ -53,6 +53,14 @@ class Tests_HtmlApi_WpHtmlProcessorSetOuterMarkup extends WP_UnitTestCase {
 			'Unclosed nested element'             => array( '<div><p target>One thought<p>And another', '', '<div><p>And another' ),
 			'Partially-closed element'            => array( '<div target>This is <em>all</em> inside the DIV</div', '', '' ),
 			'Implicitly-closed element'           => array( '<div><p target>Inside the P</div>Outside the P</p>', '', '<div></div>Outside the P</p>' ),
+
+			'Text markup'                         => array( '<span target></span>', 'Today is the best day to start.', 'Today is the best day to start.' ),
+			'Text with ampersand (raw)'           => array( '<span target></span>', 'Today & yesterday are the best days to start.', 'Today & yesterday are the best days to start.' ),
+			'Text with tag (raw)'                 => array( '<span target></span>', 'Yesterday <em>was</em> the best day to start.', 'Yesterday <em>was</em> the best day to start.' ),
+			'Text with unclosed tag (raw)'        => array( '<span target></span>', 'Yesterday <em>was the best day to start.', 'Yesterday <em>was the best day to start.' ),
+			'Text with ending tag (raw)'          => array( '<span target></span>', 'Here is no </div>', 'Here is no </div>' ),
+			'Text with scope-creating tag (raw)'  => array( '<span target></span>', '<p>Start<p>Finish<p>Repeat', '<p>Start<p>Finish<p>Repeat' ),
+			'Text with scope-ending tag (raw)'    => array( '<span target></span>', 'Sneaky closing </span> No more span.', 'Sneaky closing </span> No more span.' ),
 		);
 
 		/*


### PR DESCRIPTION
This will probably be split before merging. In the process of expanding some comments I discovered that the HTML Processor allows moving forward after finding unsupported HTML, and a new test was added to prevent this. Additionally, it reports a tag name after failing on unsupported HTML, which probably needs to be fixed in the Tag Processor, or through new logic in `WP_HTML_Processor::get_tag()` to refuse to return results if there's a parse failure. This could get complicated with reporting attributes and all.