### PR TITLE
HTML API: Introduce HTML templating

### DIFF
--- a/src/wp-content/themes/twentytwentyfour/theme.json
+++ b/src/wp-content/themes/twentytwentyfour/theme.json
@@ -247,7 +247,7 @@
 				{
 					"fontFamily": "Iowan Old Style, Apple Garamond, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
 					"name": "System Serif",
-					"slug": "system-Serif"
+					"slug": "system-serif"
 				}
 			],
 			"fontSizes": [

--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -136,6 +136,20 @@ function _register_core_block_patterns_and_categories() {
 		)
 	);
 	register_block_pattern_category(
+		'videos',
+		array(
+			'label'       => _x( 'Videos', 'Block pattern category' ),
+			'description' => __( 'Different layouts containing videos.' ),
+		)
+	);
+	register_block_pattern_category(
+		'audio',
+		array(
+			'label'       => _x( 'Audio', 'Block pattern category' ),
+			'description' => __( 'Different layouts containing audio.' ),
+		)
+	);
+	register_block_pattern_category(
 		'posts',
 		array(
 			'label'       => _x( 'Posts', 'Block pattern category' ),

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -251,7 +251,7 @@ function _get_block_templates_paths( $base_directory ) {
  * @param string $template_type 'wp_template' or 'wp_template_part'.
  * @param string $slug          Template slug.
  * @return array|null {
- *    Array with template metadata if $template_type is one of 'wp_template' or 'wp_template_part'.
+ *    Array with template metadata if $template_type is one of 'wp_template' or 'wp_template_part',
  *    null otherwise.
  *
  *    @type string   $slug      Template slug.

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -839,6 +839,8 @@ function insert_hooked_blocks( &$parsed_anchor_block, $relative_position, $hooke
 		/**
 		 * Filters the parsed block array for a given hooked block.
 		 *
+		 * The dynamic portion of the hook name, `$hooked_block_type`, refers to the block type name of the specific hooked block.
+		 *
 		 * @since 6.5.0
 		 *
 		 * @param array                   $parsed_hooked_block The parsed block array for the given hooked block type.

--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -550,13 +550,23 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 	$is_attachment_redirect = false;
 
 	if ( is_attachment() && ! get_option( 'wp_attachment_pages_enabled' ) ) {
-		$attachment_id = get_query_var( 'attachment_id' );
+		$attachment_id        = get_query_var( 'attachment_id' );
+		$attachment_post      = get_post( $attachment_id );
+		$attachment_parent_id = $attachment_post ? $attachment_post->post_parent : 0;
 
-		if ( current_user_can( 'read_post', $attachment_id ) ) {
-			$redirect_url = wp_get_attachment_url( $attachment_id );
-
-			$is_attachment_redirect = true;
+		$attachment_url = wp_get_attachment_url( $attachment_id );
+		if ( $attachment_url !== $redirect_url ) {
+			/*
+			* If an attachment is attached to a post, it inherits the parent post's status. Fetch the
+			* parent post to check its status later.
+			*/
+			if ( $attachment_parent_id ) {
+				$redirect_obj = get_post( $attachment_parent_id );
+			}
+			$redirect_url = $attachment_url;
 		}
+
+		$is_attachment_redirect = true;
 	}
 
 	$redirect['query'] = preg_replace( '#^\??&*?#', '', $redirect['query'] );

--- a/src/wp-includes/class-wp-locale-switcher.php
+++ b/src/wp-includes/class-wp-locale-switcher.php
@@ -283,7 +283,7 @@ class WP_Locale_Switcher {
 
 		$wp_locale = new WP_Locale();
 
-		WP_Translation_Controller::instance()->set_locale( $locale );
+		WP_Translation_Controller::get_instance()->set_locale( $locale );
 
 		/**
 		 * Fires when the locale is switched to or restored.

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -935,7 +935,7 @@ class WP_Theme_JSON {
 
 				if ( $duotone_support ) {
 					$root_selector    = wp_get_block_css_selector( $block_type );
-					$duotone_selector = WP_Theme_JSON::scope_selector( $root_selector, $duotone_support );
+					$duotone_selector = static::scope_selector( $root_selector, $duotone_support );
 				}
 			}
 
@@ -1078,7 +1078,7 @@ class WP_Theme_JSON {
 				$setting_nodes[ $root_settings_key ]['selector'] = $options['root_selector'];
 			}
 			if ( false !== $root_style_key ) {
-				$setting_nodes[ $root_style_key ]['selector'] = $options['root_selector'];
+				$style_nodes[ $root_style_key ]['selector'] = $options['root_selector'];
 			}
 		}
 

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2017,8 +2017,8 @@ class WP_HTML_Tag_Processor {
 		$this->token_length         = null;
 		$this->tag_name_starts_at   = null;
 		$this->tag_name_length      = null;
-		$this->text_starts_at       = 0;
-		$this->text_length          = 0;
+		$this->text_starts_at       = null;
+		$this->text_length          = null;
 		$this->is_closing_tag       = null;
 		$this->attributes           = array();
 		$this->comment_type         = null;

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2806,6 +2806,50 @@ class WP_HTML_Tag_Processor {
 	}
 
 	/**
+	 * Sets the modifiable text for the matched token, if possible.
+	 *
+	 * @param string $text Replace the modifiable text with this string.
+	 * @return bool Whether the modifiable text was updated.
+	 */
+	public function set_modifiable_text( $text ) {
+		if ( null === $this->text_starts_at || ! is_string( $text ) ) {
+			return false;
+		}
+
+		switch ( $this->get_token_name() ) {
+			case '#text':
+				$this->lexical_updates[] = new WP_HTML_Text_Replacement(
+					$this->text_starts_at,
+					$this->text_length,
+					esc_html( $text )
+				);
+				break;
+
+			case 'TEXTAREA':
+				$this->lexical_updates[] = new WP_HTML_Text_Replacement(
+					$this->text_starts_at,
+					$this->text_length,
+					preg_replace( '~</textarea~i', '&lt;/textarea', $text )
+				);
+				break;
+
+			case 'TITLE':
+				$this->lexical_updates[] = new WP_HTML_Text_Replacement(
+					$this->text_starts_at,
+					$this->text_length,
+					preg_replace( '~</title~i', '&lt;/title', $text )
+				);
+				break;
+
+			default:
+				return false;
+		}
+
+		$this->get_updated_html();
+		return true;
+	}
+
+	/**
 	 * Updates or creates a new attribute on the currently matched tag with the passed value.
 	 *
 	 * For boolean attributes special handling is provided:

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2878,14 +2878,37 @@ class WP_HTML_Tag_Processor {
 		 * > To represent a false value, the attribute has to be omitted altogether.
 		 *     - HTML5 spec, https://html.spec.whatwg.org/#boolean-attributes
 		 */
-		if ( false === $value ) {
+		if ( false === $value || null === $value ) {
 			return $this->remove_attribute( $name );
 		}
 
 		if ( true === $value ) {
 			$updated_attribute = $name;
 		} else {
-			$escaped_new_value = esc_attr( $value );
+			$tag_name        = $this->get_tag();
+			$comparable_name = strtolower( $name );
+
+			/*
+			 * Escape URL attributes.
+			 *
+			 * @see https://html.spec.whatwg.org/#attributes-3
+			 */
+			if (
+				! str_starts_with( $value, 'data:' ) && (
+					'cite' === $comparable_name ||
+					'formaction' === $comparable_name ||
+					'href' === $comparable_name ||
+					'ping' === $comparable_name ||
+					'src' === $comparable_name ||
+					( 'FORM' === $tag_name && 'action' === $comparable_name ) ||
+					( 'OBJECT' === $tag_name && 'data' === $comparable_name ) ||
+					( 'VIDEO' === $tag_name && 'poster' === $comparable_name )
+				)
+			) {
+				$escaped_new_value = esc_url( $value );
+			} else {
+				$escaped_new_value = esc_attr( $value );
+			}
 			$updated_attribute = "{$name}=\"{$escaped_new_value}\"";
 		}
 

--- a/src/wp-includes/html-api/class-wp-html-template.php
+++ b/src/wp-includes/html-api/class-wp-html-template.php
@@ -108,7 +108,7 @@ class WP_HTML_Template extends WP_HTML_Tag_Processor {
 						$spread_name = substr( $attribute_name, 3 );
 						if ( isset( $args[ $spread_name ] ) && is_array( $args[ $spread_name ] ) ) {
 							foreach ( $args[ $spread_name ] as $key => $value ) {
-								if ( true === $value || null === $value || is_string( $value ) ) {
+								if ( true === $value || false === $value || null === $value || is_string( $value ) ) {
 									$processor->set_attribute( $key, $value );
 								}
 							}
@@ -128,7 +128,7 @@ class WP_HTML_Template extends WP_HTML_Tag_Processor {
 
 						if ( array_key_exists( $name, $args ) ) {
 							$value = $args[ $name ];
-							if ( null === $value ) {
+							if ( false === $value || null === $value ) {
 								$processor->remove_attribute( $attribute_name );
 							} elseif ( true === $value ) {
 								$processor->set_attribute( $attribute_name, true );

--- a/src/wp-includes/html-api/class-wp-html-template.php
+++ b/src/wp-includes/html-api/class-wp-html-template.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * HTML API: WP_HTML_Template helper class
+ *
+ * Provides the rendering code for the WP_HTML class. This needs to exist separately as
+ * implemented so that it can subclass the WP_HTML_Tag_Processor class and gain access
+ * to the bookmarks and lexical updates, which it uses to perform string operations.
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ * @since 6.5.0
+ */
+
+/**
+ * WP_HTML_Template class.
+ *
+ * To be used only by the WP_HTML class.
+ *
+ * @since 6.5.0
+ *
+ * @access private
+ */
+class WP_HTML_Template extends WP_HTML_Tag_Processor {
+	/**
+	 * Renders an HTML template, replacing the placeholders with the provided values.
+	 *
+	 * This function looks for placeholders in the template string and will replace
+	 * them with appropriately-escaped substitutions from the given arguments, if
+	 * provided and if those arguments are strings.
+	 *
+	 * Example:
+	 *
+	 *     echo WP_HTML_Template::render(
+	 *         '<a href="</%profile_url>"></%name></a>',
+	 *         array(
+	 *             'profile_url' => 'https://profiles.example.com/username',
+	 *             'name'        => $user->display_name
+	 *         )
+	 *     );
+	 *     // Outputs: <a href="https://profiles.example.com/username">Bobby Tables</a>
+	 *
+	 * Do not escape the values supplied to the argument array! This function will escape each
+	 * parameter's value as needed and additional manual escaping may lead to incorrect output.
+	 *
+	 * ## Syntax.
+	 *
+	 * ### Substitution Placeholders.
+	 *
+	 *  - `</%named_arg>` finds `named_arg` in the arguments array, escapes its value if possible,
+	 *    and replaces the placeholder with the escaped value. These may exist inside double-quoted
+	 *    HTML tag attributes or in HTML text content between tags. They cannot be used to output a tag
+	 *    name or content inside a comment.
+	 *
+	 * ### Spread Attributes.
+	 *
+	 *  - `...named_arg` when found within an HTML tag will lookup `named_arg` in the arguments array
+	 *    and, if it's an array, will set the attribute on the tag for each key/value pair whose value
+	 *    is a string. The
+	 *
+	 * ## Notes.
+	 *
+	 *  - Attributes may only be supplied for a limited set of types: a string value assigns a double-quoted
+	 *    attribute value; `true` sets the attribute as a boolean attribute; `null` removes the attribute.
+	 *    If provided any other type of value the attribute will be ignored and its existing value persists.
+	 *
+	 *  - If multiple HTML attributes are specified for a given tag they will be applied as if calling
+	 *    `set_attribute()` in the order they are specified in the temlpate. This includes any attributes
+	 *    assigned through the attribute spread syntax.
+	 *
+	 *  - Substitutions in text nodes may only contain string values. If provided any other type of value
+	 *    the placeholder will be removed with nothing in its place.
+	 *
+	 *  - This function currently escapes all value provided in the arguments array. In the future
+	 *    it may provide the ability to nest pre-rendered HTML into the template, but this functionality
+	 *    is deferred for a future update.
+	 *
+	 *  - This function will not replace content inside of TEXTAREA, TITLE, SCRIPT, or STYLE elements.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @access private
+	 *
+	 * @param string $template The HTML template.
+	 * @param string $args     Array of key/value pairs providing substitue values for the placeholders.
+	 * @return string The rendered HTML.
+	 */
+	public static function render( $template, $args = array() ) {
+		$processor = new self( $template );
+		while ( $processor->next_token() ) {
+			$type = $processor->get_token_type();
+			$text = $processor->get_modifiable_text();
+
+			if ( '#funky-comment' === $type && strlen( $text ) > 0 && '%' === $text[0] ) {
+				$name  = substr( $text, 1 );
+				$value = isset( $args[ $name ] ) && is_string( $args[ $name ] ) ? $args[ $name ] : null;
+				$processor->set_bookmark( 'here' );
+				$processor->lexical_updates[] = new WP_HTML_Text_Replacement(
+					$processor->bookmarks['here']->start,
+					$processor->bookmarks['here']->length,
+					null === $value ? '' : esc_html( $value )
+				);
+				continue;
+			}
+
+			if ( '#tag' === $type ) {
+				foreach ( $processor->get_attribute_names_with_prefix( '' ) ?? array() as $attribute_name ) {
+					if ( str_starts_with( $attribute_name, '...' ) ) {
+						$spread_name = substr( $attribute_name, 3 );
+						if ( isset( $args[ $spread_name ] ) && is_array( $args[ $spread_name ] ) ) {
+							foreach ( $args[ $spread_name ] as $key => $value ) {
+								if ( true === $value || null === $value || is_string( $value ) ) {
+									$processor->set_attribute( $key, $value );
+								}
+							}
+						}
+						$processor->remove_attribute( $attribute_name );
+					}
+
+					$value = $processor->get_attribute( $attribute_name );
+
+					if ( ! is_string( $value ) ) {
+						continue;
+					}
+
+					$full_match = null;
+					if ( preg_match( '~^</%([^>]+)>$~', $value, $full_match ) ) {
+						$name = $full_match[1];
+
+						if ( array_key_exists( $name, $args ) ) {
+							$value = $args[ $name ];
+							if ( null === $value ) {
+								$processor->remove_attribute( $attribute_name );
+							} elseif ( true === $value ) {
+								$processor->set_attribute( $attribute_name, true );
+							} elseif ( is_string( $value ) ) {
+								$processor->set_attribute( $attribute_name, esc_attr( $args[ $name ] ) );
+							} else {
+								$processor->remove_attribute( $attribute_name );
+							}
+						} else {
+							$processor->remove_attribute( $attribute_name );
+						}
+
+						continue;
+					}
+
+					$new_value = preg_replace_callback(
+						'~</%([^>]+)>~',
+						static function ( $matches ) use ( $args ) {
+							return is_string( $args[ $matches[1] ] )
+								? esc_attr( $args[ $matches[1] ] )
+								: '';
+						},
+						$value
+					);
+
+					if ( $new_value !== $value ) {
+						$processor->set_attribute( $attribute_name, $new_value );
+					}
+				}
+			}
+		}
+
+		return $processor->get_updated_html();
+	}
+}

--- a/src/wp-includes/html-api/class-wp-html.php
+++ b/src/wp-includes/html-api/class-wp-html.php
@@ -73,7 +73,7 @@ class WP_HTML {
 	 * @access private
 	 *
 	 * @param string $template The HTML template.
-	 * @param string $args     Array of key/value pairs providing substitue values for the placeholders.
+	 * @param array  $args     Array of key/value pairs providing substitue values for the placeholders.
 	 * @return string The rendered HTML.
 	 */
 	public static function render( $template, $args ) {

--- a/src/wp-includes/html-api/class-wp-html.php
+++ b/src/wp-includes/html-api/class-wp-html.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * HTML API: WP_HTML class
+ *
+ * Provides a public interface for HTML-related functionality in WordPress.
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ * @since 6.5.0
+ */
+
+/**
+ * WP_HTML class.
+ *
+ * @since 6.5.0
+ */
+class WP_HTML {
+	/**
+	 * Renders an HTML template, replacing the placeholders with the provided values.
+	 *
+	 * This function looks for placeholders in the template string and will replace
+	 * them with appropriately-escaped substitutions from the given arguments, if
+	 * provided and if those arguments are strings.
+	 *
+	 * Example:
+	 *
+	 *     echo WP_HTML::render(
+	 *         '<a href="</%profile_url>"></%name></a>',
+	 *         array(
+	 *             'profile_url' => 'https://profiles.example.com/username',
+	 *             'name'        => $user->display_name
+	 *         )
+	 *     );
+	 *     // Outputs: <a href="https://profiles.example.com/username">Bobby Tables</a>
+	 *
+	 * Do not escape the values supplied to the argument array! This function will escape each
+	 * parameter's value as needed and additional manual escaping may lead to incorrect output.
+	 *
+	 * ## Syntax.
+	 *
+	 * ### Substitution Placeholders.
+	 *
+	 *  - `</%named_arg>` finds `named_arg` in the arguments array, escapes its value if possible,
+	 *    and replaces the placeholder with the escaped value. These may exist inside double-quoted
+	 *    HTML tag attributes or in HTML text content between tags. They cannot be used to output a tag
+	 *    name or content inside a comment.
+	 *
+	 * ### Spread Attributes.
+	 *
+	 *  - `...named_arg` when found within an HTML tag will lookup `named_arg` in the arguments array
+	 *    and, if it's an array, will set the attribute on the tag for each key/value pair whose value
+	 *    is a string. The
+	 *
+	 * ## Notes.
+	 *
+	 *  - Attributes may only be supplied for a limited set of types: a string value assigns a double-quoted
+	 *    attribute value; `true` sets the attribute as a boolean attribute; `null` removes the attribute.
+	 *    If provided any other type of value the attribute will be ignored and its existing value persists.
+	 *
+	 *  - If multiple HTML attributes are specified for a given tag they will be applied as if calling
+	 *    `set_attribute()` in the order they are specified in the temlpate. This includes any attributes
+	 *    assigned through the attribute spread syntax.
+	 *
+	 *  - Substitutions in text nodes may only contain string values. If provided any other type of value
+	 *    the placeholder will be removed with nothing in its place.
+	 *
+	 *  - This function currently escapes all value provided in the arguments array. In the future
+	 *    it may provide the ability to nest pre-rendered HTML into the template, but this functionality
+	 *    is deferred for a future update.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @access private
+	 *
+	 * @param string $template The HTML template.
+	 * @param string $args     Array of key/value pairs providing substitue values for the placeholders.
+	 * @return string The rendered HTML.
+	 */
+	public static function render( $template, $args ) {
+		return WP_HTML_Template::render( $template, $args );
+	}
+}

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -797,7 +797,7 @@ function load_textdomain( $domain, $mofile, $locale = null ) {
 		$locale = determine_locale();
 	}
 
-	$i18n_controller = WP_Translation_Controller::instance();
+	$i18n_controller = WP_Translation_Controller::get_instance();
 
 	// Ensures the correct locale is set as the current one, in case it was filtered.
 	$i18n_controller->set_locale( $locale );
@@ -911,7 +911,7 @@ function unload_textdomain( $domain, $reloadable = false ) {
 
 	// Since multiple locales are supported, reloadable text domains don't actually need to be unloaded.
 	if ( ! $reloadable ) {
-		WP_Translation_Controller::instance()->unload_textdomain( $domain );
+		WP_Translation_Controller::get_instance()->unload_textdomain( $domain );
 	}
 
 	if ( isset( $l10n[ $domain ] ) ) {

--- a/src/wp-includes/l10n/class-wp-translation-controller.php
+++ b/src/wp-includes/l10n/class-wp-translation-controller.php
@@ -42,20 +42,28 @@ final class WP_Translation_Controller {
 	protected $loaded_files = array();
 
 	/**
-	 * Returns the WP_Translation_Controller singleton.
+	 * Container for the main instance of the class.
+	 *
+	 * @since 6.5.0
+	 * @var WP_Translation_Controller|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Utility method to retrieve the main instance of the class.
+	 *
+	 * The instance will be created if it does not exist yet.
 	 *
 	 * @since 6.5.0
 	 *
 	 * @return WP_Translation_Controller
 	 */
-	public static function instance(): WP_Translation_Controller {
-		static $instance;
-
-		if ( ! $instance ) {
-			$instance = new self();
+	public static function get_instance(): WP_Translation_Controller {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
 		}
 
-		return $instance;
+		return self::$instance;
 	}
 
 	/**

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -381,14 +381,10 @@ function set_post_thumbnail_size( $width = 0, $height = 0, $crop = false ) {
  * @return string HTML IMG element for given image attachment.
  */
 function get_image_tag( $id, $alt, $title, $align, $size = 'medium' ) {
-
 	list( $img_src, $width, $height ) = image_downsize( $id, $size );
-	$hwstring                         = image_hwstring( $width, $height );
-
-	$title = $title ? 'title="' . esc_attr( $title ) . '" ' : '';
 
 	$size_class = is_array( $size ) ? implode( 'x', $size ) : $size;
-	$class      = 'align' . esc_attr( $align ) . ' size-' . esc_attr( $size_class ) . ' wp-image-' . $id;
+	$class      = "align{$align} size-{$size_class} wp-image-{$id}";
 
 	/**
 	 * Filters the value of the attachment's image tag class attribute.
@@ -403,7 +399,19 @@ function get_image_tag( $id, $alt, $title, $align, $size = 'medium' ) {
 	 */
 	$class = apply_filters( 'get_image_tag_class', $class, $id, $align, $size );
 
-	$html = '<img src="' . esc_url( $img_src ) . '" alt="' . esc_attr( $alt ) . '" ' . $title . $hwstring . 'class="' . $class . '" />';
+	$html = WP_HTML::render(
+		<<<'HTML'
+<img src="</%src>" alt="</%alt>" title="</%title>" class="</%class>" height="</%height>" width="</%width>">
+HTML,
+		array(
+			'alt'    => $alt,
+			'class'  => $class,
+			'height' => (string) $height,
+			'src'    => $img_src,
+			'title'  => empty( $title ) ? null : $title,
+			'width'  => (string) $width,
+		)
+	);
 
 	/**
 	 * Filters the HTML content for the image tag.
@@ -3603,26 +3611,14 @@ function wp_video_shortcode( $attr, $content = '' ) {
 	$html_atts = array(
 		'class'    => $atts['class'],
 		'id'       => sprintf( 'video-%d-%d', $post_id, $instance ),
-		'width'    => absint( $atts['width'] ),
-		'height'   => absint( $atts['height'] ),
-		'poster'   => esc_url( $atts['poster'] ),
+		'width'    => (string) absint( $atts['width'] ),
+		'height'   => (string) absint( $atts['height'] ),
+		'poster'   => empty( $atts['poster'] ) ? null : $atts['poster'],
 		'loop'     => wp_validate_boolean( $atts['loop'] ),
 		'autoplay' => wp_validate_boolean( $atts['autoplay'] ),
 		'muted'    => wp_validate_boolean( $atts['muted'] ),
-		'preload'  => $atts['preload'],
+		'preload'  => empty( $atts['preload'] ) ? null : $attr['preload'],
 	);
-
-	// These ones should just be omitted altogether if they are blank.
-	foreach ( array( 'poster', 'loop', 'autoplay', 'preload', 'muted' ) as $a ) {
-		if ( empty( $html_atts[ $a ] ) ) {
-			unset( $html_atts[ $a ] );
-		}
-	}
-
-	$attr_strings = array();
-	foreach ( $html_atts as $k => $v ) {
-		$attr_strings[] = $k . '="' . esc_attr( $v ) . '"';
-	}
 
 	$html = '';
 
@@ -3630,10 +3626,9 @@ function wp_video_shortcode( $attr, $content = '' ) {
 		$html .= "<!--[if lt IE 9]><script>document.createElement('video');</script><![endif]-->\n";
 	}
 
-	$html .= sprintf( '<video %s controls="controls">', implode( ' ', $attr_strings ) );
+	$html .= WP_HTML::render( '<video controls="controls" ...args>', array( 'args' => $html_atts ) );
 
 	$fileurl = '';
-	$source  = '<source type="%s" src="%s" />';
 
 	foreach ( $default_types as $fallback ) {
 		if ( ! empty( $atts[ $fallback ] ) ) {
@@ -3647,8 +3642,14 @@ function wp_video_shortcode( $attr, $content = '' ) {
 			} else {
 				$type = wp_check_filetype( $atts[ $fallback ], wp_get_mime_types() );
 			}
-			$url   = add_query_arg( '_', $instance, $atts[ $fallback ] );
-			$html .= sprintf( $source, $type['type'], esc_url( $url ) );
+
+			$html .= WP_HTML::render(
+				'<source type="</%source>" src="</%src>">',
+				array(
+					'source' => $type['type'],
+					'src'    => add_query_arg( '_', $instance, $atts[ $fallback ] ),
+				)
+			);
 		}
 	}
 
@@ -3664,11 +3665,16 @@ function wp_video_shortcode( $attr, $content = '' ) {
 	}
 	$html .= '</video>';
 
-	$width_rule = '';
-	if ( ! empty( $atts['width'] ) ) {
-		$width_rule = sprintf( 'width: %dpx;', $atts['width'] );
-	}
-	$output = sprintf( '<div style="%s" class="wp-video">%s</div>', $width_rule, $html );
+	$output = (
+		WP_HTML::render(
+			'<div class="wp-video" style="</%width>">',
+			array(
+				'width' => ! empty( $atts['width'] ) ? "width: {$atts['width']}px;" : null,
+			)
+		) .
+		$html .
+		'</div>'
+	);
 
 	/**
 	 * Filters the output of the video shortcode.

--- a/src/wp-includes/pomo/po.php
+++ b/src/wp-includes/pomo/po.php
@@ -53,7 +53,7 @@ if ( ! class_exists( 'PO', false ) ) :
 		/**
 		 * Exports all entries to PO format
 		 *
-		 * @return string sequence of mgsgid/msgstr PO strings, doesn't containt newline at the end
+		 * @return string sequence of msgid/msgstr PO strings, doesn't contain a newline at the end
 		 */
 		public function export_entries() {
 			// TODO: Sorting.
@@ -64,7 +64,7 @@ if ( ! class_exists( 'PO', false ) ) :
 		 * Exports the whole PO file as a string
 		 *
 		 * @param bool $include_headers whether to include the headers in the export
-		 * @return string ready for inclusion in PO file string for headers and all the enrtries
+		 * @return string ready for inclusion in PO file string for headers and all the entries
 		 */
 		public function export( $include_headers = true ) {
 			$res = '';
@@ -127,7 +127,7 @@ if ( ! class_exists( 'PO', false ) ) :
 			$input_string = str_replace( array_keys( $replaces ), array_values( $replaces ), $input_string );
 
 			$po = $quote . implode( "{$slash}n{$quote}{$newline}{$quote}", explode( $newline, $input_string ) ) . $quote;
-			// Add empty string on first line for readbility.
+			// Add empty string on first line for readability.
 			if ( str_contains( $input_string, $newline ) &&
 				( substr_count( $input_string, $newline ) > 1 || substr( $input_string, -strlen( $newline ) ) !== $newline ) ) {
 				$po = "$quote$quote$newline$po";
@@ -141,7 +141,7 @@ if ( ! class_exists( 'PO', false ) ) :
 		 * Gives back the original string from a PO-formatted string
 		 *
 		 * @param string $input_string PO-formatted string
-		 * @return string enascaped string
+		 * @return string unescaped string
 		 */
 		public static function unpoify( $input_string ) {
 			$escapes               = array(

--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -296,19 +296,21 @@ function get_the_content( $more_link_text = null, $strip_teaser = false, $post =
 	}
 
 	if ( null === $more_link_text ) {
-		$more_link_text = sprintf(
-			'<span aria-label="%1$s">%2$s</span>',
-			sprintf(
-				/* translators: %s: Post title. */
-				__( 'Continue reading %s' ),
-				the_title_attribute(
-					array(
-						'echo' => false,
-						'post' => $_post,
+		$more_link_text = WP_HTML::render(
+			'<span aria-label="</%label>"></%title></span>',
+			array(
+				'label' => sprintf(
+					/* translators: %s: Post title. */
+					__( 'Continue reading %s' ),
+					the_title_attribute(
+						array(
+							'echo' => false,
+							'post' => $_post,
+						)
 					)
-				)
-			),
-			__( '(more&hellip;)' )
+				),
+				'title' => __( '(more&hellip;)' ),
+			)
 		);
 	}
 
@@ -359,9 +361,17 @@ function get_the_content( $more_link_text = null, $strip_teaser = false, $post =
 
 	if ( count( $content ) > 1 ) {
 		if ( $elements['more'] ) {
-			$output .= '<span id="more-' . $_post->ID . '"></span>' . $content[1];
+			$output .= WP_HTML::render( '<span id="more-</%id>"></span>', array( 'id' => $_post->ID ) );
+			$output .= $content[1];
 		} else {
 			if ( ! empty( $more_link_text ) ) {
+				$link_html = WP_HTML::render(
+					'<a href="</%post_link>" class="more-link"></%link_text></a>',
+					array(
+						'post_link' => get_permalink( $_post ) . "#more-{$_post->ID}",
+						'link_text' => $more_link_text,
+					)
+				);
 
 				/**
 				 * Filters the Read More link text.
@@ -371,7 +381,7 @@ function get_the_content( $more_link_text = null, $strip_teaser = false, $post =
 				 * @param string $more_link_element Read More link element.
 				 * @param string $more_link_text    Read More text.
 				 */
-				$output .= apply_filters( 'the_content_more_link', ' <a href="' . get_permalink( $_post ) . "#more-{$_post->ID}\" class=\"more-link\">$more_link_text</a>", $more_link_text );
+				$output .= apply_filters( 'the_content_more_link', $link_html, $more_link_text );
 			}
 			$output = force_balance_tags( $output );
 		}

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -622,7 +622,7 @@ $GLOBALS['wp_locale'] = new WP_Locale();
 $GLOBALS['wp_locale_switcher'] = new WP_Locale_Switcher();
 $GLOBALS['wp_locale_switcher']->init();
 
-WP_Translation_Controller::instance()->set_locale( $locale );
+WP_Translation_Controller::get_instance()->set_locale( $locale );
 
 // Load the functions for the active theme, for both parent and child theme if applicable.
 foreach ( wp_get_active_and_valid_themes() as $theme ) {

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -252,6 +252,8 @@ require ABSPATH . WPINC . '/html-api/class-wp-html-open-elements.php';
 require ABSPATH . WPINC . '/html-api/class-wp-html-token.php';
 require ABSPATH . WPINC . '/html-api/class-wp-html-processor-state.php';
 require ABSPATH . WPINC . '/html-api/class-wp-html-processor.php';
+require ABSPATH . WPINC . '/html-api/class-wp-html-template.php';
+require ABSPATH . WPINC . '/html-api/class-wp-html.php';
 require ABSPATH . WPINC . '/class-wp-http.php';
 require ABSPATH . WPINC . '/class-wp-http-streams.php';
 require ABSPATH . WPINC . '/class-wp-http-curl.php';

--- a/tests/phpunit/tests/blocks/getHookedBlockMarkup.php
+++ b/tests/phpunit/tests/blocks/getHookedBlockMarkup.php
@@ -11,8 +11,17 @@
  * @group block-hooks
  */
 class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
+	const HOOKED_BLOCK_TYPE = 'tests/hooked-block';
+	const HOOKED_BLOCK      = array(
+		'blockName'    => 'tests/different-hooked-block',
+		'attrs'        => array(),
+		'innerContent' => array(),
+	);
+
 	/**
+	 * @ticket 59572
 	 * @ticket 60008
+	 * @ticket 60126
 	 *
 	 * @covers ::get_hooked_block_markup
 	 */
@@ -21,13 +30,23 @@ class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 			'blockName' => 'tests/anchor-block',
 		);
 
-		$actual = get_hooked_block_markup( $anchor_block, 'tests/hooked-block' );
-		$this->assertSame( array( 'tests/hooked-block' ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
-		$this->assertSame( '<!-- wp:tests/hooked-block /-->', $actual );
+		$actual = get_hooked_block_markup( self::HOOKED_BLOCK, self::HOOKED_BLOCK_TYPE, $anchor_block );
+		$this->assertSame(
+			array( self::HOOKED_BLOCK_TYPE ),
+			$anchor_block['attrs']['metadata']['ignoredHookedBlocks'],
+			"Hooked block type wasn't added to ignoredHookedBlocks metadata."
+		);
+		$this->assertSame(
+			'<!-- wp:' . self::HOOKED_BLOCK['blockName'] . ' /-->',
+			$actual,
+			"Markup for hooked block wasn't generated correctly."
+		);
 	}
 
 	/**
+	 * @ticket 59572
 	 * @ticket 60008
+	 * @ticket 60126
 	 *
 	 * @covers ::get_hooked_block_markup
 	 */
@@ -36,33 +55,58 @@ class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 			'blockName' => 'tests/anchor-block',
 			'attrs'     => array(
 				'metadata' => array(
-					'ignoredHookedBlocks' => array( 'tests/hooked-block' ),
+					'ignoredHookedBlocks' => array( self::HOOKED_BLOCK_TYPE ),
 				),
 			),
 		);
 
-		$actual = get_hooked_block_markup( $anchor_block, 'tests/hooked-block' );
-		$this->assertSame( array( 'tests/hooked-block' ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
-		$this->assertSame( '', $actual );
+		$actual = get_hooked_block_markup( self::HOOKED_BLOCK, self::HOOKED_BLOCK_TYPE, $anchor_block );
+		$this->assertSame(
+			array( self::HOOKED_BLOCK_TYPE ),
+			$anchor_block['attrs']['metadata']['ignoredHookedBlocks'],
+			"ignoredHookedBlocks metadata shouldn't have been modified."
+		);
+		$this->assertSame(
+			'',
+			$actual,
+			"No markup should've been generated for ignored hooked block."
+		);
 	}
 
 	/**
+	 * @ticket 59572
 	 * @ticket 60008
+	 * @ticket 60126
 	 *
 	 * @covers ::get_hooked_block_markup
 	 */
 	public function test_get_hooked_block_markup_adds_to_ignored_hooked_blocks() {
+		$other_hooked_block_type = 'tests/other-hooked-block';
+		$other_hooked_block      = array(
+			'blockName'    => $other_hooked_block_type,
+			'attrs'        => array(),
+			'innerContent' => array(),
+		);
+
 		$anchor_block = array(
 			'blockName' => 'tests/anchor-block',
 			'attrs'     => array(
 				'metadata' => array(
-					'ignoredHookedBlocks' => array( 'tests/hooked-block' ),
+					'ignoredHookedBlocks' => array( self::HOOKED_BLOCK_TYPE ),
 				),
 			),
 		);
 
-		$actual = get_hooked_block_markup( $anchor_block, 'tests/other-hooked-block' );
-		$this->assertSame( array( 'tests/hooked-block', 'tests/other-hooked-block' ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
-		$this->assertSame( '<!-- wp:tests/other-hooked-block /-->', $actual );
+		$actual = get_hooked_block_markup( $other_hooked_block, $other_hooked_block_type, $anchor_block );
+		$this->assertSame(
+			array( self::HOOKED_BLOCK_TYPE, $other_hooked_block_type ),
+			$anchor_block['attrs']['metadata']['ignoredHookedBlocks'],
+			"Newly hooked block should've been added to ignoredHookedBlocks metadata while retaining previously ignored one."
+		);
+		$this->assertSame(
+			'<!-- wp:' . $other_hooked_block_type . ' /-->',
+			$actual,
+			"Markup for newly hooked block should've been generated."
+		);
 	}
 }

--- a/tests/phpunit/tests/blocks/insertHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocks.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * Tests for the insert_hooked_blocks function.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ *
+ * @since 6.5.0
+ *
+ * @group blocks
+ * @group block-hooks
+ */
+class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
+	const ANCHOR_BLOCK_TYPE       = 'tests/anchor-block';
+	const HOOKED_BLOCK_TYPE       = 'tests/hooked-block';
+	const OTHER_HOOKED_BLOCK_TYPE = 'tests/other-hooked-block';
+
+	const HOOKED_BLOCKS = array(
+		self::ANCHOR_BLOCK_TYPE => array(
+			'after'  => array( self::HOOKED_BLOCK_TYPE ),
+			'before' => array( self::OTHER_HOOKED_BLOCK_TYPE ),
+		),
+	);
+
+	/**
+	 * @ticket 59572
+	 * @ticket 60126
+	 *
+	 * @covers ::insert_hooked_blocks
+	 */
+	public function test_insert_hooked_blocks_adds_metadata() {
+		$anchor_block = array(
+			'blockName' => self::ANCHOR_BLOCK_TYPE,
+		);
+
+		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
+		$this->assertSame(
+			array( self::HOOKED_BLOCK_TYPE ),
+			$anchor_block['attrs']['metadata']['ignoredHookedBlocks'],
+			"Hooked block type wasn't added to ignoredHookedBlocks metadata."
+		);
+		$this->assertSame(
+			'<!-- wp:' . self::HOOKED_BLOCK_TYPE . ' /-->',
+			$actual,
+			"Markup for hooked block wasn't generated correctly."
+		);
+	}
+
+	/**
+	 * @ticket 59572
+	 * @ticket 60126
+	 *
+	 * @covers ::insert_hooked_blocks
+	 */
+	public function test_insert_hooked_blocks_if_block_is_already_hooked() {
+		$anchor_block = array(
+			'blockName' => 'tests/anchor-block',
+			'attrs'     => array(
+				'metadata' => array(
+					'ignoredHookedBlocks' => array( self::HOOKED_BLOCK_TYPE ),
+				),
+			),
+		);
+
+		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
+		$this->assertSame(
+			array( self::HOOKED_BLOCK_TYPE ),
+			$anchor_block['attrs']['metadata']['ignoredHookedBlocks'],
+			"ignoredHookedBlocks metadata shouldn't have been modified."
+		);
+		$this->assertSame(
+			'',
+			$actual,
+			"No markup should've been generated for ignored hooked block."
+		);
+	}
+
+	/**
+	 * @ticket 59572
+	 * @ticket 60126
+	 *
+	 * @covers ::insert_hooked_blocks
+	 */
+	public function test_insert_hooked_blocks_adds_to_ignored_hooked_blocks() {
+		$anchor_block = array(
+			'blockName' => 'tests/anchor-block',
+			'attrs'     => array(
+				'metadata' => array(
+					'ignoredHookedBlocks' => array( self::HOOKED_BLOCK_TYPE ),
+				),
+			),
+		);
+
+		$actual = insert_hooked_blocks( $anchor_block, 'before', self::HOOKED_BLOCKS, array() );
+		$this->assertSame(
+			array( self::HOOKED_BLOCK_TYPE, self::OTHER_HOOKED_BLOCK_TYPE ),
+			$anchor_block['attrs']['metadata']['ignoredHookedBlocks'],
+			"Newly hooked block should've been added to ignoredHookedBlocks metadata while retaining previously ignored one."
+		);
+		$this->assertSame(
+			'<!-- wp:' . self::OTHER_HOOKED_BLOCK_TYPE . ' /-->',
+			$actual,
+			"Markup for newly hooked block should've been generated."
+		);
+	}
+
+	/**
+	 * @ticket 59572
+	 * @ticket 60126
+	 *
+	 * @covers ::insert_hooked_blocks
+	 */
+	public function test_insert_hooked_blocks_filter_can_set_attributes() {
+		$anchor_block = array(
+			'blockName'    => self::ANCHOR_BLOCK_TYPE,
+			'attrs'        => array(
+				'layout' => array(
+					'type' => 'constrained',
+				),
+			),
+			'innerContent' => array(),
+		);
+
+		$filter = function ( $parsed_hooked_block, $relative_position, $parsed_anchor_block ) {
+			// Is the hooked block adjacent to the anchor block?
+			if ( 'before' !== $relative_position && 'after' !== $relative_position ) {
+				return $parsed_hooked_block;
+			}
+
+			// Does the anchor block have a layout attribute?
+			if ( isset( $parsed_anchor_block['attrs']['layout'] ) ) {
+				// Copy the anchor block's layout attribute to the hooked block.
+				$parsed_hooked_block['attrs']['layout'] = $parsed_anchor_block['attrs']['layout'];
+			}
+
+			return $parsed_hooked_block;
+		};
+		add_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter, 10, 3 );
+		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
+		remove_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter, 10, 3 );
+
+		$this->assertSame(
+			array( self::HOOKED_BLOCK_TYPE ),
+			$anchor_block['attrs']['metadata']['ignoredHookedBlocks'],
+			"Hooked block type wasn't added to ignoredHookedBlocks metadata."
+		);
+		$this->assertSame(
+			'<!-- wp:' . self::HOOKED_BLOCK_TYPE . ' {"layout":{"type":"constrained"}} /-->',
+			$actual,
+			"Markup wasn't generated correctly for hooked block with attribute set by filter."
+		);
+	}
+
+	/**
+	 * @ticket 59572
+	 * @ticket 60126
+	 *
+	 * @covers ::insert_hooked_blocks
+	 */
+	public function test_insert_hooked_blocks_filter_can_wrap_block() {
+		$anchor_block = array(
+			'blockName'    => self::ANCHOR_BLOCK_TYPE,
+			'attrs'        => array(
+				'layout' => array(
+					'type' => 'constrained',
+				),
+			),
+			'innerContent' => array(),
+		);
+
+		$filter = function ( $parsed_hooked_block ) {
+			if ( self::HOOKED_BLOCK_TYPE !== $parsed_hooked_block['blockName'] ) {
+				return $parsed_hooked_block;
+			}
+
+			// Wrap the block in a Group block.
+			return array(
+				'blockName'    => 'core/group',
+				'attrs'        => array(),
+				'innerBlocks'  => array( $parsed_hooked_block ),
+				'innerContent' => array(
+					'<div class="wp-block-group">',
+					null,
+					'</div>',
+				),
+			);
+		};
+		add_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter, 10, 3 );
+		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
+		remove_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter, 10, 3 );
+
+		$this->assertSame(
+			array( self::HOOKED_BLOCK_TYPE ),
+			$anchor_block['attrs']['metadata']['ignoredHookedBlocks'],
+			"Hooked block type wasn't added to ignoredHookedBlocks metadata."
+		);
+		$this->assertSame(
+			'<!-- wp:group --><div class="wp-block-group"><!-- wp:' . self::HOOKED_BLOCK_TYPE . ' /--></div><!-- /wp:group -->',
+			$actual,
+			"Markup wasn't generated correctly for hooked block wrapped in Group block by filter."
+		);
+	}
+}

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -14,7 +14,7 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 		parent::set_up();
 		wp_set_current_user( self::$author_id );
 
-		add_filter( 'pre_option_wp_attachment_pages_enabled', '__return_true' );
+		update_option( 'wp_attachment_pages_enabled', 1 );
 	}
 
 	/**
@@ -407,23 +407,83 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 	}
 
 	/**
+	 * Test canonical redirects for attachment pages when the option is disabled.
+	 *
 	 * @ticket 57913
+	 * @ticket 59866
+	 *
+	 * @dataProvider data_canonical_attachment_page_redirect_with_option_disabled
 	 */
-	public function test_canonical_attachment_page_redirect_with_option_disabled() {
-		add_filter( 'pre_option_wp_attachment_pages_enabled', '__return_false' );
+	public function test_canonical_attachment_page_redirect_with_option_disabled( $expected, $user = null, $parent_post_status = '' ) {
+		update_option( 'wp_attachment_pages_enabled', 0 );
+
+		if ( '' !== $parent_post_status ) {
+			$parent_post_id = self::factory()->post->create(
+				array(
+					'post_status' => $parent_post_status,
+				)
+			);
+		} else {
+			$parent_post_id = 0;
+		}
 
 		$filename = DIR_TESTDATA . '/images/test-image.jpg';
 		$contents = file_get_contents( $filename );
 		$upload   = wp_upload_bits( wp_basename( $filename ), null, $contents );
 
-		$attachment_id   = $this->_make_attachment( $upload );
+		$attachment_id   = $this->_make_attachment( $upload, $parent_post_id );
+		$attachment_url  = wp_get_attachment_url( $attachment_id );
 		$attachment_page = get_permalink( $attachment_id );
+
+		// Set as anonymous/logged out user.
+		if ( null !== $user ) {
+			wp_set_current_user( $user );
+		}
 
 		$this->go_to( $attachment_page );
 
-		$url      = redirect_canonical( $attachment_page, false );
-		$expected = wp_get_attachment_url( $attachment_id );
+		$url = redirect_canonical( $attachment_page, false );
+		if ( is_string( $expected ) ) {
+			$expected = str_replace( '%%attachment_url%%', $attachment_url, $expected );
+		}
 
 		$this->assertSame( $expected, $url );
+	}
+
+	/**
+	 * Data provider for test_canonical_attachment_page_redirect_with_option_disabled().
+	 *
+	 * @return array[]
+	 */
+	public function data_canonical_attachment_page_redirect_with_option_disabled() {
+		return array(
+			'logged out user, no parent'      => array(
+				'%%attachment_url%%',
+				0,
+			),
+			'logged in user, no parent'       => array(
+				'%%attachment_url%%',
+			),
+			'logged out user, private parent' => array(
+				null,
+				0,
+				'private',
+			),
+			'logged in user, private parent'  => array(
+				'%%attachment_url%%',
+				null,
+				'private',
+			),
+			'logged out user, public parent'  => array(
+				'%%attachment_url%%',
+				0,
+				'publish',
+			),
+			'logged in user, public parent'   => array(
+				'%%attachment_url%%',
+				null,
+				'publish',
+			),
+		);
 	}
 }

--- a/tests/phpunit/tests/canonical/postStatus.php
+++ b/tests/phpunit/tests/canonical/postStatus.php
@@ -169,8 +169,6 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 		self::setup_custom_types();
-
-		add_filter( 'pre_option_wp_attachment_pages_enabled', '__return_true' );
 	}
 
 	/**
@@ -223,8 +221,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 	 * @param string $user_role User role.
 	 * @param string $requested Requested URL.
 	 * @param string $expected  Expected URL.
+	 * @param string $enable_attachment_pages Whether to enable attachment pages. Default true.
 	 */
-	public function test_canonical_redirects_to_plain_permalinks( $post_key, $user_role, $requested, $expected ) {
+	public function test_canonical_redirects_to_plain_permalinks( $post_key, $user_role, $requested, $expected, $enable_attachment_pages = true ) {
+		if ( $enable_attachment_pages ) {
+			update_option( 'wp_attachment_pages_enabled', 1 );
+		} else {
+			update_option( 'wp_attachment_pages_enabled', 0 );
+		}
+
 		wp_set_current_user( self::$users[ $user_role ] );
 		$this->set_permalink_structure( '' );
 		$post = self::$posts[ $post_key ];
@@ -243,12 +248,7 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 	/**
 	 * Data provider for test_canonical_redirects_to_plain_permalinks.
 	 *
-	 * @return array[] Array of arguments for tests {
-	 *     @type string $post_key  Post key used for creating fixtures.
-	 *     @type string $user_role User role.
-	 *     @type string $requested Requested URL.
-	 *     @type string $expected  Expected URL.
-	 * }
+	 * @return array[]
 	 */
 	public function data_canonical_redirects_to_plain_permalinks() {
 		$data              = array();
@@ -273,6 +273,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?post_type=page&p=%ID%',
 					'/?post_type=page&p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-page",
+					$user,
+					'/?post_type=page&p=%ID%',
+					'/?post_type=page&p=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -280,6 +289,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					"/?name=$post_key-post",
 					"/?name=$post_key-post",
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					"/?name=$post_key-post",
+					"/?name=$post_key-post",
+					false,
 				);
 
 				// Ensure rss redirects to rss2.
@@ -288,6 +306,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&p=%ID%',
 					'/?feed=rss2&p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?feed=rss&p=%ID%',
+					'/?feed=rss2&p=%ID%',
+					false,
 				);
 
 				// Ensure rss redirects to rss2.
@@ -296,6 +323,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&page_id=%ID%',
 					'/?feed=rss2&page_id=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-page",
+					$user,
+					'/?feed=rss&page_id=%ID%',
+					'/?feed=rss2&page_id=%ID%',
+					false,
 				);
 			}
 		}
@@ -311,6 +347,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?post_type=page&p=%ID%',
 					'/?post_type=page&p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-page",
+					$user,
+					'/?post_type=page&p=%ID%',
+					'/?post_type=page&p=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -318,6 +363,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					"/?name=$post_key-post",
 					"/?name=$post_key-post",
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					"/?name=$post_key-post",
+					"/?name=$post_key-post",
+					false,
 				);
 
 				// Ensure rss redirects to rss2.
@@ -326,6 +380,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&p=%ID%',
 					'/?feed=rss2&p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?feed=rss&p=%ID%',
+					'/?feed=rss2&p=%ID%',
+					false,
 				);
 
 				// Ensure rss redirects to rss2.
@@ -334,6 +397,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&page_id=%ID%',
 					'/?feed=rss2&page_id=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-page",
+					$user,
+					'/?feed=rss&page_id=%ID%',
+					'/?feed=rss2&page_id=%ID%',
+					false,
 				);
 			}
 
@@ -347,6 +419,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?post_type=page&p=%ID%',
 					'/?post_type=page&p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-page",
+					$user,
+					'/?post_type=page&p=%ID%',
+					'/?post_type=page&p=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -354,6 +435,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					"/?name=$post_key-post",
 					"/?name=$post_key-post",
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					"/?name=$post_key-post",
+					"/?name=$post_key-post",
+					false,
 				);
 
 				// Ensure post's existence is not demonstrated by changing rss to rss2.
@@ -362,6 +452,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&p=%ID%',
 					'/?feed=rss&p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?feed=rss&p=%ID%',
+					'/?feed=rss&p=%ID%',
+					false,
 				);
 
 				// Ensure post's existence is not demonstrated by changing rss to rss2.
@@ -370,6 +469,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&page_id=%ID%',
 					'/?feed=rss&page_id=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-page",
+					$user,
+					'/?feed=rss&page_id=%ID%',
+					'/?feed=rss&page_id=%ID%',
+					false,
 				);
 			}
 		}
@@ -385,6 +493,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?post_type=page&p=%ID%',
 					'/?post_type=page&p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-page",
+					$user,
+					'/?post_type=page&p=%ID%',
+					'/?post_type=page&p=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -392,6 +509,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					"/?name=$post_key-post",
 					"/?name=$post_key-post",
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					"/?name=$post_key-post",
+					"/?name=$post_key-post",
+					false,
 				);
 
 				// Ensure post's existence is not demonstrated by changing rss to rss2.
@@ -400,6 +526,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&p=%ID%',
 					'/?feed=rss&p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?feed=rss&p=%ID%',
+					'/?feed=rss&p=%ID%',
+					false,
 				);
 
 				// Ensure post's existence is not demonstrated by changing rss to rss2.
@@ -408,6 +543,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&page_id=%ID%',
 					'/?feed=rss&page_id=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-page",
+					$user,
+					'/?feed=rss&page_id=%ID%',
+					'/?feed=rss&page_id=%ID%',
+					false,
 				);
 			}
 		}
@@ -423,6 +567,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?post_type=page&p=%ID%',
 					'/?post_type=page&p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-page",
+					$user,
+					'/?post_type=page&p=%ID%',
+					'/?post_type=page&p=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -430,6 +583,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					"/?name=$post_key-post",
 					"/?name=$post_key-post",
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					"/?name=$post_key-post",
+					"/?name=$post_key-post",
+					false,
 				);
 
 				// Ensure post's existence is not demonstrated by changing rss to rss2.
@@ -438,6 +600,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&p=%ID%',
 					'/?feed=rss&p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?feed=rss&p=%ID%',
+					'/?feed=rss&p=%ID%',
+					false,
 				);
 
 				// Ensure post's existence is not demonstrated by changing rss to rss2.
@@ -446,6 +617,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&page_id=%ID%',
 					'/?feed=rss&page_id=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-page",
+					$user,
+					'/?feed=rss&page_id=%ID%',
+					'/?feed=rss&page_id=%ID%',
+					false,
 				);
 			}
 		}
@@ -457,6 +637,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?p=%ID%',
 					'/?a-public-cpt=a-public-cpt',
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?p=%ID%',
+					'/?a-public-cpt=a-public-cpt',
+					false,
 				);
 
 				$data[] = array(
@@ -464,6 +653,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?attachment_id=%ID%',
 					'/?attachment_id=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-attachment",
+					$user,
+					'/?attachment_id=%ID%',
+					'/?attachment_id=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -471,6 +669,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					"/?name=$post_key&post_type=$post_key",
 					"/?name=$post_key&post_type=$post_key",
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					"/?name=$post_key&post_type=$post_key",
+					"/?name=$post_key&post_type=$post_key",
+					false,
 				);
 
 				// Ensure rss is replaced by rss2.
@@ -479,6 +686,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&p=%ID%',
 					'/?a-public-cpt=a-public-cpt&feed=rss2',
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?feed=rss&p=%ID%',
+					'/?a-public-cpt=a-public-cpt&feed=rss2',
+					false,
 				);
 			}
 
@@ -488,6 +704,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?p=%ID%',
 					'/?p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?p=%ID%',
+					'/?p=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -495,6 +720,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?attachment_id=%ID%',
 					'/?attachment_id=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-attachment",
+					$user,
+					'/?attachment_id=%ID%',
+					'/?attachment_id=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -502,6 +736,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					"/?name=$post_key&post_type=$post_key",
 					"/?name=$post_key&post_type=$post_key",
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					"/?name=$post_key&post_type=$post_key",
+					"/?name=$post_key&post_type=$post_key",
+					false,
 				);
 
 				// Ensure rss is not replaced with rss2.
@@ -510,6 +753,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&p=%ID%',
 					'/?feed=rss&p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?feed=rss&p=%ID%',
+					'/?feed=rss&p=%ID%',
+					false,
 				);
 			}
 		}
@@ -521,6 +773,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?p=%ID%',
 					'/?p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?p=%ID%',
+					'/?p=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -528,6 +789,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?attachment_id=%ID%',
 					'/?attachment_id=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-attachment",
+					$user,
+					'/?attachment_id=%ID%',
+					'/?attachment_id=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -535,6 +805,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					"/?name=$post_key&post_type=$post_key",
 					"/?name=$post_key&post_type=$post_key",
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					"/?name=$post_key&post_type=$post_key",
+					"/?name=$post_key&post_type=$post_key",
+					false,
 				);
 
 				$data[] = array(
@@ -542,6 +821,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&p=%ID%',
 					'/?feed=rss&p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?feed=rss&p=%ID%',
+					'/?feed=rss&p=%ID%',
+					false,
 				);
 			}
 		}
@@ -559,8 +847,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 	 * @param string $user_role User role.
 	 * @param string $requested Requested URL.
 	 * @param string $expected  Expected URL.
+	 * @param string $enable_attachment_pages Whether to enable attachment pages. Default true.
 	 */
-	public function test_canonical_redirects_to_pretty_permalinks( $post_key, $user_role, $requested, $expected ) {
+	public function test_canonical_redirects_to_pretty_permalinks( $post_key, $user_role, $requested, $expected, $enable_attachment_pages = true ) {
+		if ( $enable_attachment_pages ) {
+			update_option( 'wp_attachment_pages_enabled', 1 );
+		} else {
+			update_option( 'wp_attachment_pages_enabled', 0 );
+		}
+
 		wp_set_current_user( self::$users[ $user_role ] );
 		$this->set_permalink_structure( '/%postname%/' );
 		$post = self::$posts[ $post_key ];
@@ -605,6 +900,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?p=%ID%',
 					"/$post_key-post/",
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?p=%ID%',
+					"/$post_key-post/",
+					false,
 				);
 
 				$data[] = array(
@@ -612,6 +916,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?attachment_id=%ID%',
 					"/$post_key-post/$post_key-inherited-attachment/",
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-attachment",
+					$user,
+					'/?attachment_id=%ID%',
+					'/?attachment_id=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -619,6 +932,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?post_type=page&p=%ID%',
 					"/$post_key-page/",
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-page",
+					$user,
+					'/?post_type=page&p=%ID%',
+					"/$post_key-page/",
+					false,
 				);
 
 				$data[] = array(
@@ -626,6 +948,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?page_id=%ID%',
 					"/$post_key-page/",
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-page",
+					$user,
+					'/?page_id=%ID%',
+					"/$post_key-page/",
+					false,
 				);
 
 				$data[] = array(
@@ -633,6 +964,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					"/?name=$post_key-post",
 					"/$post_key-post/",
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					"/?name=$post_key-post",
+					"/$post_key-post/",
+					false,
 				);
 
 				$data[] = array(
@@ -640,6 +980,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&p=%ID%',
 					"/$post_key-post/feed/",
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?feed=rss&p=%ID%',
+					"/$post_key-post/feed/",
+					false,
 				);
 
 				$data[] = array(
@@ -647,6 +996,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&page_id=%ID%',
 					"/$post_key-page/feed/",
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-page",
+					$user,
+					'/?feed=rss&page_id=%ID%',
+					"/$post_key-page/feed/",
+					false,
 				);
 			}
 		}
@@ -658,6 +1016,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?p=%ID%',
 					"/$post_key-post/",
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?p=%ID%',
+					"/$post_key-post/",
+					false,
 				);
 
 				$data[] = array(
@@ -665,6 +1032,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?attachment_id=%ID%',
 					"/$post_key-post/$post_key-inherited-attachment/",
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-attachment",
+					$user,
+					'/?attachment_id=%ID%',
+					'/?attachment_id=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -672,6 +1048,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?post_type=page&p=%ID%',
 					"/$post_key-page/",
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-page",
+					$user,
+					'/?post_type=page&p=%ID%',
+					"/$post_key-page/",
+					false,
 				);
 
 				$data[] = array(
@@ -679,6 +1064,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?page_id=%ID%',
 					"/$post_key-page/",
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-page",
+					$user,
+					'/?page_id=%ID%',
+					"/$post_key-page/",
+					false,
 				);
 
 				$data[] = array(
@@ -686,6 +1080,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					"/?name=$post_key-post",
 					"/$post_key-post/",
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					"/?name=$post_key-post",
+					"/$post_key-post/",
+					false,
 				);
 
 				$data[] = array(
@@ -693,6 +1096,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&p=%ID%',
 					"/$post_key-post/feed/",
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?feed=rss&p=%ID%',
+					"/$post_key-post/feed/",
+					false,
 				);
 
 				$data[] = array(
@@ -700,6 +1112,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&page_id=%ID%',
 					"/$post_key-page/feed/",
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-page",
+					$user,
+					'/?feed=rss&page_id=%ID%',
+					"/$post_key-page/feed/",
+					false,
 				);
 			}
 
@@ -709,6 +1130,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?p=%ID%',
 					'/?p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?p=%ID%',
+					'/?p=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -716,6 +1146,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?attachment_id=%ID%',
 					'/?attachment_id=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-attachment",
+					$user,
+					'/?attachment_id=%ID%',
+					'/?attachment_id=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -723,6 +1162,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?post_type=page&p=%ID%',
 					'/?post_type=page&p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-page",
+					$user,
+					'/?post_type=page&p=%ID%',
+					'/?post_type=page&p=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -730,6 +1178,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?page_id=%ID%',
 					'/?page_id=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-page",
+					$user,
+					'/?page_id=%ID%',
+					'/?page_id=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -737,6 +1194,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					"/?name=$post_key-post",
 					"/?name=$post_key-post",
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					"/?name=$post_key-post",
+					"/?name=$post_key-post",
+					false,
 				);
 
 				$data[] = array(
@@ -744,6 +1210,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&p=%ID%',
 					'/?feed=rss&p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?feed=rss&p=%ID%',
+					'/?feed=rss&p=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -751,6 +1226,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&page_id=%ID%',
 					'/?feed=rss&page_id=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-page",
+					$user,
+					'/?feed=rss&page_id=%ID%',
+					'/?feed=rss&page_id=%ID%',
+					false,
 				);
 			}
 		}
@@ -762,6 +1246,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?p=%ID%',
 					"/$post_key/$post_key/",
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?p=%ID%',
+					"/$post_key/$post_key/",
+					false,
 				);
 
 				$data[] = array(
@@ -769,6 +1262,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?attachment_id=%ID%',
 					"/$post_key/$post_key/$post_key-inherited-attachment/",
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-attachment",
+					$user,
+					'/?attachment_id=%ID%',
+					'/?attachment_id=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -776,6 +1278,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					"/?name=$post_key&post_type=$post_key",
 					"/$post_key/$post_key/?post_type=$post_key",
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					"/?name=$post_key&post_type=$post_key",
+					"/$post_key/$post_key/?post_type=$post_key",
+					false,
 				);
 
 				$data[] = array(
@@ -783,6 +1294,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&p=%ID%',
 					"/$post_key/$post_key/feed/",
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?feed=rss&p=%ID%',
+					"/$post_key/$post_key/feed/",
+					false,
 				);
 			}
 
@@ -792,6 +1312,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?p=%ID%',
 					'/?p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?p=%ID%',
+					'/?p=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -799,6 +1328,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?attachment_id=%ID%',
 					'/?attachment_id=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-attachment",
+					$user,
+					'/?attachment_id=%ID%',
+					'/?attachment_id=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -806,6 +1344,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					"/?name=$post_key&post_type=$post_key",
 					"/?name=$post_key&post_type=$post_key",
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					"/?name=$post_key&post_type=$post_key",
+					"/?name=$post_key&post_type=$post_key",
+					false,
 				);
 
 				$data[] = array(
@@ -813,6 +1360,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&p=%ID%',
 					'/?feed=rss&p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?feed=rss&p=%ID%',
+					'/?feed=rss&p=%ID%',
+					false,
 				);
 			}
 		}
@@ -824,6 +1380,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?p=%ID%',
 					'/?p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?p=%ID%',
+					'/?p=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -831,7 +1396,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?attachment_id=%ID%',
 					'/?attachment_id=%ID%',
-					// "/$post_key-inherited-attachment/",
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-attachment",
+					$user,
+					'/?attachment_id=%ID%',
+					'/?attachment_id=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -839,6 +1412,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					"/?name=$post_key&post_type=$post_key",
 					"/?name=$post_key&post_type=$post_key",
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					"/?name=$post_key&post_type=$post_key",
+					"/?name=$post_key&post_type=$post_key",
+					false,
 				);
 
 				$data[] = array(
@@ -846,6 +1428,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&p=%ID%',
 					'/?feed=rss&p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?feed=rss&p=%ID%',
+					'/?feed=rss&p=%ID%',
+					false,
 				);
 			}
 		}
@@ -857,6 +1448,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?p=%ID%',
 					'/?p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?p=%ID%',
+					'/?p=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -864,6 +1464,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?attachment_id=%ID%',
 					'/?attachment_id=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-attachment",
+					$user,
+					'/?attachment_id=%ID%',
+					'/?attachment_id=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -871,6 +1480,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?post_type=page&p=%ID%',
 					'/?post_type=page&p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-page",
+					$user,
+					'/?post_type=page&p=%ID%',
+					'/?post_type=page&p=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -878,6 +1496,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?page_id=%ID%',
 					'/?page_id=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-page",
+					$user,
+					'/?page_id=%ID%',
+					'/?page_id=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -885,6 +1512,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					"/?name=$post_key-post",
 					"/?name=$post_key-post",
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					"/?name=$post_key-post",
+					"/?name=$post_key-post",
+					false,
 				);
 
 				$data[] = array(
@@ -892,6 +1528,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&p=%ID%',
 					'/?feed=rss&p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?feed=rss&p=%ID%',
+					'/?feed=rss&p=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -899,6 +1544,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&page_id=%ID%',
 					'/?feed=rss&page_id=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-page",
+					$user,
+					'/?feed=rss&page_id=%ID%',
+					'/?feed=rss&page_id=%ID%',
+					false,
 				);
 			}
 		}
@@ -910,6 +1564,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?p=%ID%',
 					'/?p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?p=%ID%',
+					'/?p=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -917,6 +1580,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?attachment_id=%ID%',
 					'/?attachment_id=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-attachment",
+					$user,
+					'/?attachment_id=%ID%',
+					'/?attachment_id=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -924,6 +1596,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/trash-post/trash-post-inherited-attachment/',
 					'/?attachment_id=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-attachment",
+					$user,
+					'/trash-post/trash-post-inherited-attachment/',
+					'/?attachment_id=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -931,6 +1612,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/trash-post__trashed/trash-post-inherited-attachment/',
 					'/?attachment_id=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-attachment",
+					$user,
+					'/trash-post__trashed/trash-post-inherited-attachment/',
+					'/?attachment_id=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -938,6 +1628,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?post_type=page&p=%ID%',
 					'/?post_type=page&p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-page",
+					$user,
+					'/?post_type=page&p=%ID%',
+					'/?post_type=page&p=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -945,6 +1644,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?page_id=%ID%',
 					'/?page_id=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-page",
+					$user,
+					'/?page_id=%ID%',
+					'/?page_id=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -952,6 +1660,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					"/?name=$post_key-post",
 					"/?name=$post_key-post",
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					"/?name=$post_key-post",
+					"/?name=$post_key-post",
+					false,
 				);
 
 				$data[] = array(
@@ -959,6 +1676,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&p=%ID%',
 					'/?feed=rss&p=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					$post_key,
+					$user,
+					'/?feed=rss&p=%ID%',
+					'/?feed=rss&p=%ID%',
+					false,
 				);
 
 				$data[] = array(
@@ -966,6 +1692,15 @@ class Tests_Canonical_PostStatus extends WP_Canonical_UnitTestCase {
 					$user,
 					'/?feed=rss&page_id=%ID%',
 					'/?feed=rss&page_id=%ID%',
+					true,
+				);
+
+				$data[] = array(
+					"$post_key-page",
+					$user,
+					'/?feed=rss&page_id=%ID%',
+					'/?feed=rss&page_id=%ID%',
+					false,
 				);
 			}
 		}

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
@@ -514,7 +514,11 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 	 * @covers WP_HTML_Processor::seek
 	 */
 	public function test_can_seek_back_and_forth() {
-		$p = WP_HTML_Processor::create_fragment( '<div><p one><div><p><div two><p><div><p><div><p three>' );
+		$p = WP_HTML_Processor::create_fragment(
+			<<<'HTML'
+<div>text<p one>more stuff<div><![CDATA[this is not real CDATA]]><p><!-- hi --><div two><p><div><p>three comes soon<div><p three>' );
+HTML
+		);
 
 		// Find first tag of interest.
 		while ( $p->next_tag() && null === $p->get_attribute( 'one' ) ) {

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor-token-scanning.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor-token-scanning.php
@@ -1,0 +1,734 @@
+<?php
+/**
+ * Unit tests covering WP_HTML_Tag_Processor token-scanning functionality.
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ *
+ * @since 6.5.0
+ *
+ * @group html-api
+ *
+ * @coversDefaultClass WP_HTML_Tag_Processor
+ */
+class Tests_HtmlApi_WpHtmlProcessor_Token_Scanning extends WP_UnitTestCase {
+	/**
+	 * Ensures that scanning finishes in a complete form when the document is empty.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_completes_empty_document() {
+		$processor = new WP_HTML_Tag_Processor( '' );
+
+		$this->assertFalse(
+			$processor->next_token(),
+			"Should not have found any tokens but found {$processor->get_token_type()}."
+		);
+	}
+
+	/**
+	 * Ensures that normative text nodes are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_text_node() {
+		$processor = new WP_HTML_Tag_Processor( 'Hello, World!' );
+		$processor->next_token();
+
+		$this->assertSame(
+			'#text',
+			$processor->get_token_type(),
+			"Should have found #text token type but found {$processor->get_token_type()} instead."
+		);
+
+		$this->assertSame(
+			'Hello, World!',
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+
+	/**
+	 * Ensures that normative Elements are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_element() {
+		$processor = new WP_HTML_Tag_Processor( '<div id="test" inert>Hello, World!</div>' );
+		$processor->next_token();
+
+		$this->assertSame(
+			'DIV',
+			$processor->get_token_name(),
+			"Should have found DIV tag name but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertSame(
+			'test',
+			$processor->get_attribute( 'id' ),
+			"Should have found id attribute value 'test' but found {$processor->get_attribute( 'id' )} instead."
+		);
+
+		$this->assertTrue(
+			$processor->get_attribute( 'inert' ),
+			"Should have found boolean attribute 'inert' but didn't."
+		);
+
+		$attributes     = $processor->get_attribute_names_with_prefix( '' );
+		$attribute_list = array_map( 'Tests_HtmlApi_WpHtmlProcessor_Token_Scanning::quoted', $attributes );
+		$this->assertSame(
+			array( 'id', 'inert' ),
+			$attributes,
+			'Should have found only two attributes but found ' . implode( ', ', $attribute_list ) . ' instead.'
+		);
+
+		$this->assertSame(
+			'',
+			$processor->get_modifiable_text(),
+			"Should have found empty modifiable text but found '{$processor->get_modifiable_text()}' instead."
+		);
+	}
+
+	/**
+	 * Ensures that normative SCRIPT elements are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_script_element() {
+		$processor = new WP_HTML_Tag_Processor( '<script type="module">console.log( "Hello, World!" );</script>' );
+		$processor->next_token();
+
+		$this->assertSame(
+			'SCRIPT',
+			$processor->get_token_name(),
+			"Should have found SCRIPT tag name but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertSame(
+			'module',
+			$processor->get_attribute( 'type' ),
+			"Should have found type attribute value 'module' but found {$processor->get_attribute( 'type' )} instead."
+		);
+
+		$attributes     = $processor->get_attribute_names_with_prefix( '' );
+		$attribute_list = array_map( 'Tests_HtmlApi_WpHtmlProcessor_Token_Scanning::quoted', $attributes );
+		$this->assertSame(
+			array( 'type' ),
+			$attributes,
+			"Should have found single 'type' attribute but found " . implode( ', ', $attribute_list ) . ' instead.'
+		);
+
+		$this->assertSame(
+			'console.log( "Hello, World!" );',
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+
+	/**
+	 * Ensures that normative TEXTAREA elements are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_textarea_element() {
+		$processor = new WP_HTML_Tag_Processor(
+			<<<HTML
+<textarea rows=30 cols="80">
+Is <HTML> &gt; XHTML?
+</textarea>
+HTML
+		);
+		$processor->next_token();
+
+		$this->assertSame(
+			'TEXTAREA',
+			$processor->get_token_name(),
+			"Should have found TEXTAREA tag name but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertSame(
+			'30',
+			$processor->get_attribute( 'rows' ),
+			"Should have found rows attribute value 'module' but found {$processor->get_attribute( 'rows' )} instead."
+		);
+
+		$this->assertSame(
+			'80',
+			$processor->get_attribute( 'cols' ),
+			"Should have found cols attribute value 'module' but found {$processor->get_attribute( 'cols' )} instead."
+		);
+
+		$attributes     = $processor->get_attribute_names_with_prefix( '' );
+		$attribute_list = array_map( 'Tests_HtmlApi_WpHtmlProcessor_Token_Scanning::quoted', $attributes );
+		$this->assertSame(
+			array( 'rows', 'cols' ),
+			$attributes,
+			'Should have found only two attributes but found ' . implode( ', ', $attribute_list ) . ' instead.'
+		);
+
+		// Note that the leading newline should be removed from the TEXTAREA contents.
+		$this->assertSame(
+			"Is <HTML> > XHTML?\n",
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+
+	/**
+	 * Ensures that normative TITLE elements are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_title_element() {
+		$processor = new WP_HTML_Tag_Processor(
+			<<<HTML
+<title class="multi-line-title">
+Is <HTML> &gt; XHTML?
+</title>
+HTML
+		);
+		$processor->next_token();
+
+		$this->assertSame(
+			'TITLE',
+			$processor->get_token_name(),
+			"Should have found TITLE tag name but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertSame(
+			'multi-line-title',
+			$processor->get_attribute( 'class' ),
+			"Should have found class attribute value 'multi-line-title' but found {$processor->get_attribute( 'rows' )} instead."
+		);
+
+		$attributes     = $processor->get_attribute_names_with_prefix( '' );
+		$attribute_list = array_map( 'Tests_HtmlApi_WpHtmlProcessor_Token_Scanning::quoted', $attributes );
+		$this->assertSame(
+			array( 'class' ),
+			$attributes,
+			'Should have found only one attribute but found ' . implode( ', ', $attribute_list ) . ' instead.'
+		);
+
+		$this->assertSame(
+			"\nIs <HTML> > XHTML?\n",
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+
+	/**
+	 * Ensures that normative RAWTEXT elements are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 *
+	 * @dataProvider data_rawtext_elements
+	 *
+	 * @param string $tag_name The name of the RAWTEXT tag to test.
+	 */
+	public function test_basic_assertion_rawtext_elements( $tag_name ) {
+		$processor = new WP_HTML_Tag_Processor(
+			<<<HTML
+<{$tag_name} class="multi-line-title">
+Is <HTML> &gt; XHTML?
+</{$tag_name}>
+HTML
+		);
+		$processor->next_token();
+
+		$this->assertSame(
+			$tag_name,
+			$processor->get_token_name(),
+			"Should have found {$tag_name} tag name but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertSame(
+			'multi-line-title',
+			$processor->get_attribute( 'class' ),
+			"Should have found class attribute value 'multi-line-title' but found {$processor->get_attribute( 'rows' )} instead."
+		);
+
+		$attributes     = $processor->get_attribute_names_with_prefix( '' );
+		$attribute_list = array_map( 'Tests_HtmlApi_WpHtmlProcessor_Token_Scanning::quoted', $attributes );
+		$this->assertSame(
+			array( 'class' ),
+			$attributes,
+			'Should have found only one attribute but found ' . implode( ', ', $attribute_list ) . ' instead.'
+		);
+
+		$this->assertSame(
+			"\nIs <HTML> &gt; XHTML?\n",
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[].
+	 */
+	public function data_rawtext_elements() {
+		return array(
+			'IFRAME'   => array( 'IFRAME' ),
+			'NOEMBED'  => array( 'NOEMBED' ),
+			'NOFRAMES' => array( 'NOFRAMES' ),
+			'STYLE'    => array( 'STYLE' ),
+			'XMP'      => array( 'XMP' ),
+		);
+	}
+
+	/**
+	 * Ensures that normative CDATA sections are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_cdata_section() {
+		$processor = new WP_HTML_Tag_Processor( '<![CDATA[this is a comment]]>' );
+		$processor->next_token();
+
+		$this->assertSame(
+			'#comment',
+			$processor->get_token_name(),
+			"Should have found comment token but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertSame(
+			WP_HTML_Processor::COMMENT_AS_CDATA_LOOKALIKE,
+			$processor->get_comment_type(),
+			'Should have detected a CDATA-like invalid comment.'
+		);
+
+		$this->assertNull(
+			$processor->get_tag(),
+			'Should not have been able to query tag name on non-element token.'
+		);
+
+		$this->assertNull(
+			$processor->get_attribute( 'type' ),
+			'Should not have been able to query attributes on non-element token.'
+		);
+
+		$this->assertSame(
+			'this is a comment',
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+
+	/**
+	 * Ensures that abruptly-closed CDATA sections are properly parsed as comments.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_abruptly_closed_cdata_section() {
+		$processor = new WP_HTML_Tag_Processor( '<![CDATA[this is > a comment]]>' );
+		$processor->next_token();
+
+		$this->assertSame(
+			'#comment',
+			$processor->get_token_name(),
+			"Should have found a bogus comment but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertNull(
+			$processor->get_tag(),
+			'Should not have been able to query tag name on non-element token.'
+		);
+
+		$this->assertNull(
+			$processor->get_attribute( 'type' ),
+			'Should not have been able to query attributes on non-element token.'
+		);
+
+		$this->assertSame(
+			'[CDATA[this is ',
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+
+		$processor->next_token();
+
+		$this->assertSame(
+			'#text',
+			$processor->get_token_name(),
+			"Should have found text node but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertSame(
+			' a comment]]>',
+			$processor->get_modifiable_text(),
+			'Should have found remaining syntax from abruptly-closed CDATA section.'
+		);
+	}
+
+	/**
+	 * Ensures that normative Processing Instruction nodes are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_processing_instruction() {
+		$processor = new WP_HTML_Tag_Processor( '<?wp-bit {"just": "kidding"}?>' );
+		$processor->next_token();
+
+		$this->assertSame(
+			'#comment',
+			$processor->get_token_name(),
+			"Should have found comment token but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertSame(
+			WP_HTML_Processor::COMMENT_AS_PI_NODE_LOOKALIKE,
+			$processor->get_comment_type(),
+			'Should have detected a Processing Instruction-like invalid comment.'
+		);
+
+		$this->assertSame(
+			'wp-bit',
+			$processor->get_tag(),
+			"Should have found PI target as tag name but found {$processor->get_tag()} instead."
+		);
+
+		$this->assertNull(
+			$processor->get_attribute( 'type' ),
+			'Should not have been able to query attributes on non-element token.'
+		);
+
+		$this->assertSame(
+			' {"just": "kidding"}',
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+
+	/**
+	 * Ensures that abruptly-closed Processing Instruction nodes are properly parsed as comments.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_abruptly_closed_processing_instruction() {
+		$processor = new WP_HTML_Tag_Processor( '<?version=">=5.3.6"?>' );
+		$processor->next_token();
+
+		$this->assertSame(
+			'#comment',
+			$processor->get_token_type(),
+			"Should have found bogus comment but found {$processor->get_token_type()} instead."
+		);
+
+		$this->assertSame(
+			'#comment',
+			$processor->get_token_name(),
+			"Should have found #comment as name but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertNull(
+			$processor->get_tag(),
+			'Should not have been able to query tag name on non-element token.'
+		);
+
+		$this->assertNull(
+			$processor->get_attribute( 'type' ),
+			'Should not have been able to query attributes on non-element token.'
+		);
+
+		$this->assertSame(
+			'version="',
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+
+		$processor->next_token();
+
+		$this->assertSame(
+			'=5.3.6"?>',
+			$processor->get_modifiable_text(),
+			'Should have found remaining syntax from abruptly-closed Processing Instruction.'
+		);
+	}
+
+	/**
+	 * Ensures that common comments are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @dataProvider data_common_comments
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 *
+	 * @param string $html Contains the comment in full.
+	 * @param string $text Contains the appropriate modifiable text.
+	 */
+	public function test_basic_assertion_common_comments( $html, $text ) {
+		$processor = new WP_HTML_Tag_Processor( $html );
+		$processor->next_token();
+
+		$this->assertSame(
+			'#comment',
+			$processor->get_token_type(),
+			"Should have found comment but found {$processor->get_token_type()} instead."
+		);
+
+		$this->assertSame(
+			'#comment',
+			$processor->get_token_name(),
+			"Should have found #comment as name but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertNull(
+			$processor->get_tag(),
+			'Should not have been able to query tag name on non-element token.'
+		);
+
+		$this->assertNull(
+			$processor->get_attribute( 'type' ),
+			'Should not have been able to query attributes on non-element token.'
+		);
+
+		$this->assertSame(
+			$text,
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[].
+	 */
+	public function data_common_comments() {
+		return array(
+			'Shortest comment'        => array( '<!-->', '' ),
+			'Short comment'           => array( '<!--->', '' ),
+			'Short comment w/o text'  => array( '<!---->', '' ),
+			'Short comment with text' => array( '<!----->', '-' ),
+			'PI node without target'  => array( '<? missing?>', ' missing?' ),
+			'Invalid PI node'         => array( '<?/missing/>', '/missing/' ),
+			'Invalid ! directive'     => array( '<!something else>', 'something else' ),
+		);
+	}
+
+	/**
+	 * Ensures that normative HTML comments are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_html_comment() {
+		$processor = new WP_HTML_Tag_Processor( '<!-- wp:paragraph -->' );
+		$processor->next_token();
+
+		$this->assertSame(
+			'#comment',
+			$processor->get_token_type(),
+			"Should have found comment but found {$processor->get_token_type()} instead."
+		);
+
+		$this->assertSame(
+			'#comment',
+			$processor->get_token_name(),
+			"Should have found #comment as name but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertNull(
+			$processor->get_tag(),
+			'Should not have been able to query tag name on non-element token.'
+		);
+
+		$this->assertNull(
+			$processor->get_attribute( 'type' ),
+			'Should not have been able to query attributes on non-element token.'
+		);
+
+		$this->assertSame(
+			' wp:paragraph ',
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+
+	/**
+	 * Ensures that normative DOCTYPE elements are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_doctype() {
+		$processor = new WP_HTML_Tag_Processor( '<!DOCTYPE html>' );
+		$processor->next_token();
+
+		$this->assertSame(
+			'#doctype',
+			$processor->get_token_type(),
+			"Should have found DOCTYPE but found {$processor->get_token_type()} instead."
+		);
+
+		$this->assertSame(
+			'html',
+			$processor->get_token_name(),
+			"Should have found 'html' as name but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertNull(
+			$processor->get_tag(),
+			'Should not have been able to query tag name on non-element token.'
+		);
+
+		$this->assertNull(
+			$processor->get_attribute( 'type' ),
+			'Should not have been able to query attributes on non-element token.'
+		);
+
+		$this->assertSame(
+			' html',
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+
+	/**
+	 * Ensures that normative presumptuous tag closers (empty closers) are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_presumptuous_tag() {
+		$processor = new WP_HTML_Tag_Processor( '</>' );
+		$processor->next_token();
+
+		$this->assertSame(
+			'#presumptuous-tag',
+			$processor->get_token_type(),
+			"Should have found presumptuous tag but found {$processor->get_token_type()} instead."
+		);
+
+		$this->assertSame(
+			'#presumptuous-tag',
+			$processor->get_token_name(),
+			"Should have found #presumptuous-tag as name but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertNull(
+			$processor->get_tag(),
+			'Should not have been able to query tag name on non-element token.'
+		);
+
+		$this->assertNull(
+			$processor->get_attribute( 'type' ),
+			'Should not have been able to query attributes on non-element token.'
+		);
+
+		$this->assertSame(
+			'',
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+
+	/**
+	 * Ensures that normative funky comments are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_funky_comment() {
+		$processor = new WP_HTML_Tag_Processor( '</%url>' );
+		$processor->next_token();
+
+		$this->assertSame(
+			'#funky-comment',
+			$processor->get_token_type(),
+			"Should have found funky comment but found {$processor->get_token_type()} instead."
+		);
+
+		$this->assertSame(
+			'#funky-comment',
+			$processor->get_token_name(),
+			"Should have found #funky-comment as name but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertNull(
+			$processor->get_tag(),
+			'Should not have been able to query tag name on non-element token.'
+		);
+
+		$this->assertNull(
+			$processor->get_attribute( 'type' ),
+			'Should not have been able to query attributes on non-element token.'
+		);
+
+		$this->assertSame(
+			'%url',
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+
+	/**
+	 * Test helper that wraps a string in double quotes.
+	 *
+	 * @param string $s The string to wrap in double-quotes.
+	 * @return string The string wrapped in double-quotes.
+	 */
+	private static function quoted( $s ) {
+		return "\"$s\"";
+	}
+}

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -557,8 +557,10 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 		$p = new WP_HTML_Tag_Processor( '<script>abc</script>' );
 
 		$p->next_tag();
-		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ) ), 'Did not find the </script> tag closer' );
-		$this->assertTrue( $p->is_tag_closer(), 'Indicated a <script> tag opener is a tag closer' );
+		$this->assertFalse(
+			$p->next_tag( array( 'tag_closers' => 'visit' ) ),
+			'Should not have found closing SCRIPT tag when closing an opener.'
+		);
 
 		$p = new WP_HTML_Tag_Processor( 'abc</script>' );
 		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ) ), 'Did not find the </script> tag closer when there was no tag opener' );
@@ -566,8 +568,10 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 		$p = new WP_HTML_Tag_Processor( '<textarea>abc</textarea>' );
 
 		$p->next_tag();
-		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ) ), 'Did not find the </textarea> tag closer' );
-		$this->assertTrue( $p->is_tag_closer(), 'Indicated a <textarea> tag opener is a tag closer' );
+		$this->assertFalse(
+			$p->next_tag( array( 'tag_closers' => 'visit' ) ),
+			'Should not have found closing TEXTAREA when closing an opener.'
+		);
 
 		$p = new WP_HTML_Tag_Processor( 'abc</textarea>' );
 		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ) ), 'Did not find the </textarea> tag closer when there was no tag opener' );
@@ -575,8 +579,10 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 		$p = new WP_HTML_Tag_Processor( '<title>abc</title>' );
 
 		$p->next_tag();
-		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ) ), 'Did not find the </title> tag closer' );
-		$this->assertTrue( $p->is_tag_closer(), 'Indicated a <title> tag opener is a tag closer' );
+		$this->assertFalse(
+			$p->next_tag( array( 'tag_closers' => 'visit' ) ),
+			'Should not have found closing TITLE when closing an opener.'
+		);
 
 		$p = new WP_HTML_Tag_Processor( 'abc</title>' );
 		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ) ), 'Did not find the </title> tag closer when there was no tag opener' );
@@ -2357,6 +2363,7 @@ HTML;
 			'No tags'                => array( 'this is nothing more than a text node' ),
 			'Text with comments'     => array( 'One <!-- sneaky --> comment.' ),
 			'Empty tag closer'       => array( '</>' ),
+			'CDATA as HTML comment'  => array( '<![CDATA[this closes at the first &gt;]>' ),
 			'Processing instruction' => array( '<?xml version="1.0"?>' ),
 			'Combination XML-like'   => array( '<!DOCTYPE xml><?xml version=""?><!-- this is not a real document. --><![CDATA[it only serves as a test]]>' ),
 		);
@@ -2410,7 +2417,6 @@ HTML;
 			'Incomplete CDATA'                     => array( '<![CDATA[something inside of here needs to get out' ),
 			'Partial CDATA'                        => array( '<![CDA' ),
 			'Partially closed CDATA]'              => array( '<![CDATA[cannot escape]' ),
-			'Partially closed CDATA]>'             => array( '<![CDATA[cannot escape]>' ),
 			'Unclosed IFRAME'                      => array( '<iframe><div>' ),
 			'Unclosed NOEMBED'                     => array( '<noembed><div>' ),
 			'Unclosed NOFRAMES'                    => array( '<noframes><div>' ),
@@ -2507,7 +2513,7 @@ HTML;
 			),
 			'tag inside of CDATA'      => array(
 				'input'    => '<![CDATA[This <is> a <strong id="yes">HTML Tag</strong>]]><span>test</span>',
-				'expected' => '<![CDATA[This <is> a <strong id="yes">HTML Tag</strong>]]><span class="firstTag" foo="bar">test</span>',
+				'expected' => '<![CDATA[This <is> a <strong class="firstTag" foo="bar" id="yes">HTML Tag</strong>]]><span class="secondTag">test</span>',
 			),
 		);
 	}

--- a/tests/phpunit/tests/html-api/wpHtmlTemplate.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTemplate.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Unit tests covering WP_HTML_Template functionality.
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ *
+ * @since 6.5.0
+ *
+ * @group html-api
+ *
+ * @coversDefaultClass WP_HTML_Template
+ */
+
+class Tests_HtmlApi_WpHtmlTemplate extends WP_UnitTestCase {
+	/**
+	 * Demonstrates how to pass values into an HTML template.
+	 *
+	 * @ticket 60229
+	 */
+	public function test_basic_render() {
+		$html = WP_HTML_Template::render(
+			'<div class="is-test </%class>" ...div-args inert="</%is_inert>">Just a </%count> test</div>',
+			array(
+				'count'    => '<strong>Hi <3</strong>',
+				'class'    => '5>4',
+				'is_inert' => 'inert',
+				'div-args' => array(
+					'class'    => 'hoover',
+					'disabled' => true,
+				),
+			)
+		);
+
+		$this->assertSame(
+			'<div disabled class="hoover"  inert="inert">Just a &lt;strong&gt;Hi &lt;3&lt;/strong&gt; test</div>',
+			$html,
+			'Failed to properly render template.'
+		);
+	}
+}

--- a/tests/phpunit/tests/html-api/wpHtmlTemplate.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTemplate.php
@@ -38,4 +38,51 @@ class Tests_HtmlApi_WpHtmlTemplate extends WP_UnitTestCase {
 			'Failed to properly render template.'
 		);
 	}
+
+	/**
+	 * Ensures that basic attacks on attribute names and values are blocked.
+	 *
+	 * @ticket 60229
+	 *
+	 * @covers WP_HTML::render
+	 */
+	public function test_cannot_break_out_of_tag_with_malicious_attribute_name() {
+		$html = WP_HTML_Template::render(
+			'<div class="</%class>" ...args>',
+			array(
+				'class' => '"><script>alert("hi")</script>',
+				'args'  => array(
+					'"> double-quoted escape' => 'busted!',
+					'> tag escape'            => 'busted!',
+				),
+			)
+		);
+
+		// The output here should include an escaped `class` attribute and no others, also no other tags.
+		$processor = new WP_HTML_Tag_Processor( $html );
+		$processor->next_tag();
+
+		$this->assertSame(
+			'DIV',
+			$processor->get_tag(),
+			"Expected to find DIV tag but found {$processor->get_tag()} instead."
+		);
+
+		$this->assertSame(
+			'"><script>alert("hi")</script>',
+			$processor->get_attribute( 'class' ),
+			'Should have found escaped `class` attribute.'
+		);
+
+		$this->assertSame(
+			array( 'class' ),
+			$processor->get_attribute_names_with_prefix( '' ),
+			'Should have set `class` attribute and no others.'
+		);
+
+		$this->assertFalse(
+			$processor->next_tag(),
+			"Should not have found any other tags but found {$processor->get_tag()} instead."
+		);
+	}
 }

--- a/tests/phpunit/tests/l10n/wpTranslationController.php
+++ b/tests/phpunit/tests/l10n/wpTranslationController.php
@@ -30,9 +30,9 @@ class WP_Translation_Controller_Tests extends WP_UnitTestCase {
 
 		$compat_instance = $l10n['wp-tests-domain'] ?? null;
 
-		$is_loaded = WP_Translation_Controller::instance()->is_textdomain_loaded( 'wp-tests-domain' );
-		$headers   = WP_Translation_Controller::instance()->get_headers( 'wp-tests-domain' );
-		$entries   = WP_Translation_Controller::instance()->get_entries( 'wp-tests-domain' );
+		$is_loaded = WP_Translation_Controller::get_instance()->is_textdomain_loaded( 'wp-tests-domain' );
+		$headers   = WP_Translation_Controller::get_instance()->get_headers( 'wp-tests-domain' );
+		$entries   = WP_Translation_Controller::get_instance()->get_entries( 'wp-tests-domain' );
 
 		$unload_successful = unload_textdomain( 'wp-tests-domain' );
 
@@ -76,7 +76,7 @@ class WP_Translation_Controller_Tests extends WP_UnitTestCase {
 
 		$is_loaded_wp = is_textdomain_loaded( 'wp-tests-domain' );
 
-		$is_loaded = WP_Translation_Controller::instance()->is_textdomain_loaded( 'wp-tests-domain' );
+		$is_loaded = WP_Translation_Controller::get_instance()->is_textdomain_loaded( 'wp-tests-domain' );
 
 		remove_filter( 'override_load_textdomain', '__return_true' );
 
@@ -102,7 +102,7 @@ class WP_Translation_Controller_Tests extends WP_UnitTestCase {
 	public function test_load_textdomain_prefers_php_files_by_default() {
 		$load_successful = load_textdomain( 'wp-tests-domain', DIR_TESTDATA . '/pomo/simple.mo' );
 
-		$instance = WP_Translation_Controller::instance();
+		$instance = WP_Translation_Controller::get_instance();
 
 		$is_loaded = $instance->is_textdomain_loaded( 'wp-tests-domain', 'en_US' );
 
@@ -259,9 +259,9 @@ class WP_Translation_Controller_Tests extends WP_UnitTestCase {
 
 		$compat_instance = $l10n['wp-tests-domain'] ?? null;
 
-		$is_loaded = WP_Translation_Controller::instance()->is_textdomain_loaded( 'wp-tests-domain' );
-		$headers   = WP_Translation_Controller::instance()->get_headers( 'wp-tests-domain' );
-		$entries   = WP_Translation_Controller::instance()->get_entries( 'wp-tests-domain' );
+		$is_loaded = WP_Translation_Controller::get_instance()->is_textdomain_loaded( 'wp-tests-domain' );
+		$headers   = WP_Translation_Controller::get_instance()->get_headers( 'wp-tests-domain' );
+		$entries   = WP_Translation_Controller::get_instance()->get_entries( 'wp-tests-domain' );
 
 		$this->assertNull( $compat_instance, 'Compat instance was not removed' );
 		$this->assertTrue( $unload_successful, 'Text domain not successfully unloaded' );
@@ -281,13 +281,13 @@ class WP_Translation_Controller_Tests extends WP_UnitTestCase {
 
 		$unload_successful = unload_textdomain( 'wp-tests-domain' );
 
-		$is_loaded = WP_Translation_Controller::instance()->is_textdomain_loaded( 'wp-tests-domain' );
+		$is_loaded = WP_Translation_Controller::get_instance()->is_textdomain_loaded( 'wp-tests-domain' );
 
 		remove_filter( 'override_unload_textdomain', '__return_true' );
 
 		$unload_successful_after = unload_textdomain( 'wp-tests-domain' );
 
-		$is_loaded_after = WP_Translation_Controller::instance()->is_textdomain_loaded( 'wp-tests-domain' );
+		$is_loaded_after = WP_Translation_Controller::get_instance()->is_textdomain_loaded( 'wp-tests-domain' );
 
 		$this->assertTrue( $unload_successful );
 		$this->assertTrue( $is_loaded );
@@ -317,14 +317,14 @@ class WP_Translation_Controller_Tests extends WP_UnitTestCase {
 
 		$actual = __( 'Invalid parameter.' );
 
-		$this->assertTrue( WP_Translation_Controller::instance()->is_textdomain_loaded() );
-		$this->assertTrue( WP_Translation_Controller::instance()->is_textdomain_loaded( 'default', 'es_ES' ) );
+		$this->assertTrue( WP_Translation_Controller::get_instance()->is_textdomain_loaded() );
+		$this->assertTrue( WP_Translation_Controller::get_instance()->is_textdomain_loaded( 'default', 'es_ES' ) );
 
 		restore_previous_locale();
 
 		$actual_2 = __( 'Invalid parameter.' );
 
-		$this->assertTrue( WP_Translation_Controller::instance()->is_textdomain_loaded( 'default', 'es_ES' ) );
+		$this->assertTrue( WP_Translation_Controller::get_instance()->is_textdomain_loaded( 'default', 'es_ES' ) );
 
 		$this->assertSame( 'Parámetro no válido. ', $actual );
 		$this->assertSame( 'Invalid parameter.', $actual_2 );
@@ -336,7 +336,7 @@ class WP_Translation_Controller_Tests extends WP_UnitTestCase {
 	 * @covers ::change_locale
 	 */
 	public function test_switch_to_locale_translations_stay_loaded_custom_textdomain() {
-		$this->assertSame( 'en_US', WP_Translation_Controller::instance()->get_locale() );
+		$this->assertSame( 'en_US', WP_Translation_Controller::get_instance()->get_locale() );
 
 		require_once DIR_TESTDATA . '/plugins/internationalized-plugin.php';
 
@@ -346,16 +346,16 @@ class WP_Translation_Controller_Tests extends WP_UnitTestCase {
 
 		$actual = i18n_plugin_test();
 
-		$this->assertSame( 'es_ES', WP_Translation_Controller::instance()->get_locale() );
-		$this->assertTrue( WP_Translation_Controller::instance()->is_textdomain_loaded( 'internationalized-plugin', 'es_ES' ) );
-		$this->assertTrue( WP_Translation_Controller::instance()->is_textdomain_loaded( 'default', 'es_ES' ) );
-		$this->assertFalse( WP_Translation_Controller::instance()->is_textdomain_loaded( 'foo-bar', 'es_ES' ) );
+		$this->assertSame( 'es_ES', WP_Translation_Controller::get_instance()->get_locale() );
+		$this->assertTrue( WP_Translation_Controller::get_instance()->is_textdomain_loaded( 'internationalized-plugin', 'es_ES' ) );
+		$this->assertTrue( WP_Translation_Controller::get_instance()->is_textdomain_loaded( 'default', 'es_ES' ) );
+		$this->assertFalse( WP_Translation_Controller::get_instance()->is_textdomain_loaded( 'foo-bar', 'es_ES' ) );
 
 		restore_previous_locale();
 
 		$after = i18n_plugin_test();
 
-		$this->assertTrue( WP_Translation_Controller::instance()->is_textdomain_loaded( 'internationalized-plugin', 'es_ES' ) );
+		$this->assertTrue( WP_Translation_Controller::get_instance()->is_textdomain_loaded( 'internationalized-plugin', 'es_ES' ) );
 
 		$this->assertSame( 'This is a dummy plugin', $before );
 		$this->assertSame( 'Este es un plugin dummy', $actual );

--- a/tests/phpunit/tests/l10n/wpTranslationsConvert.php
+++ b/tests/phpunit/tests/l10n/wpTranslationsConvert.php
@@ -10,8 +10,8 @@ class WP_Translation_Controller_Convert_Tests extends WP_UnitTestCase {
 	 * @covers ::instance
 	 */
 	public function test_get_instance() {
-		$instance  = WP_Translation_Controller::instance();
-		$instance2 = WP_Translation_Controller::instance();
+		$instance  = WP_Translation_Controller::get_instance();
+		$instance2 = WP_Translation_Controller::get_instance();
 
 		$this->assertSame( $instance, $instance2 );
 	}

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -3210,7 +3210,6 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	 *
 	 * @param array $styles An array with style definitions.
 	 * @param array $path   Path to the desired properties.
-	 *
 	 */
 	public function test_get_property_value_should_return_string_for_invalid_paths_or_null_values( $styles, $path ) {
 		$reflection_class = new ReflectionClass( WP_Theme_JSON::class );
@@ -4938,5 +4937,34 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 
 		$this->assertEquals( $small_font, $styles['blocks']['core/quote']['variations']['plain']['typography']['fontSize'], 'Block variations: font-size' );
 		$this->assertEquals( $secondary_color, $styles['blocks']['core/quote']['variations']['plain']['color']['background'], 'Block variations: color' );
+	}
+
+	/**
+	 * Tests that a custom root selector is correctly applied when generating a stylesheet.
+	 *
+	 * @ticket 60343
+	 */
+	public function test_get_stylesheet_custom_root_selector() {
+		$theme_json = new WP_Theme_JSON(
+			array(
+				'version' => WP_Theme_JSON::LATEST_SCHEMA,
+				'styles'  => array(
+					'color' => array(
+						'text' => 'teal',
+					),
+				),
+			),
+			'default'
+		);
+
+		$options = array( 'root_selector' => '.custom' );
+		$actual  = $theme_json->get_stylesheet( array( 'styles' ), null, $options );
+
+		// Results also include root site blocks styles which hard code
+		// `body { margin: 0;}`.
+		$this->assertEquals(
+			'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.custom{color: teal;}',
+			$actual
+		);
 	}
 }


### PR DESCRIPTION
Trac ticket: Core-60229

🚧👷‍♂️🏗️ This feature is currently being proposed for the *WordPress 6.6* release cycle, being pushed back from 6.5 to allow for more time to let the design work proceed.

**To be recreated** in the WordPress repo once WordPress/WordPress-develop#5683 merges.

## Todo

 - [ ] embed replacement inside the Tag Processor
 - [ ] don't allow replacement of escaped funky comment syntax (currently occurs inside attribute value based on how this is built at the moment)
 - [ ] figure out what rules need to apply for nested HTML
 - [ ] figure out how to differentiate nested HTML without requiring sigils or other extra syntax

## Description

Currently only renders text data:

 - does not render nested HTML (escapes everything)
 - does not escape URLs differently than other attributes
 - relies on `esc_attr()` and `esc_html()` which today are the same thing in WordPress, but which could be greatly expanded to improve the overall escaping situation

```php
echo WP_HTML_Template::render(
	<<<HTML
<a href="</%url>">
	<img src="</%url>">
	</%url>
</a>
HTML,
	array( 'url' => 'https://s.wp.com/i/atat.png?w=640&h=480&alt="atat>atst"' ),
);
```

outputs

```html
<a href="https://s.wp.com/i/atat.png?w=640&amp;h=480&amp;alt=&quot;atat&gt;atst&quot;">
<img src="https://s.wp.com/i/atat.png?w=640&amp;h=480&amp;alt=&quot;atat&gt;atst&quot;">
https://s.wp.com/i/atat.png?w=640&amp;h=480&amp;alt=&quot;atat&gt;atst&quot;
</a>
```

This proposed templating syntax uses closing tags containing invalid tag names, so-called "funky comments," as placeholders, because they are converted to HTML comments in the DOM and because there is near universal existing support for them in all browsers, and because the syntax cannot be nested. The % at the front indicates that the value for the placeholder should come from the args array with a key named according to what follows the %.