### PR TITLE
Use strcasecmp over strtoupper

### DIFF
--- a/src/wp-includes/class-wp-token-map.php
+++ b/src/wp-includes/class-wp-token-map.php
@@ -579,19 +579,16 @@ class WP_Token_Map {
 	 * @return string|null Mapped value of lookup key if found, otherwise `null`.
 	 */
 	private function read_small_token( $text, $offset, &$matched_token_byte_length, $case_sensitivity = 'case-sensitive' ) {
-		$ignore_case  = 'ascii-case-insensitive' === $case_sensitivity;
-		$small_length = strlen( $this->small_words );
-		$search_text  = substr( $text, $offset, $this->key_length );
-		if ( $ignore_case ) {
-			$search_text = strtoupper( $search_text );
-		}
+		$ignore_case   = 'ascii-case-insensitive' === $case_sensitivity;
+		$small_length  = strlen( $this->small_words );
+		$search_text   = substr( $text, $offset, $this->key_length );
 		$starting_char = $search_text[0];
 
 		$at = 0;
 		while ( $at < $small_length ) {
 			if (
 				$starting_char !== $this->small_words[ $at ] &&
-				( ! $ignore_case || strtoupper( $this->small_words[ $at ] ) !== $starting_char )
+				( ! $ignore_case || 0 !== strcasecmp( $this->small_words[ $at ], $starting_char ) )
 			) {
 				$at += $this->key_length + 1;
 				continue;
@@ -605,7 +602,7 @@ class WP_Token_Map {
 
 				if (
 					$search_text[ $adjust ] !== $this->small_words[ $at + $adjust ] &&
-					( ! $ignore_case || strtoupper( $this->small_words[ $at + $adjust ] !== $search_text[ $adjust ] ) )
+					( ! $ignore_case || 0 !== strcasecmp( $this->small_words[ $at + $adjust ], $search_text[ $adjust ] ) )
 				) {
 					$at += $this->key_length + 1;
 					continue 2;

--- a/src/wp-includes/html-api/class-wp-html-decoder.php
+++ b/src/wp-includes/html-api/class-wp-html-decoder.php
@@ -39,7 +39,7 @@ class WP_HTML_Decoder {
 
 		while ( $search_at < $search_length && $haystack_at < $haystack_end ) {
 			$chars_match = $loose_case
-				? strtolower( $haystack[ $haystack_at ] ) === strtolower( $search_text[ $search_at ] )
+				? 0 === strcasecmp( $haystack[ $haystack_at ], $search_text[ $search_at ] )
 				: $haystack[ $haystack_at ] === $search_text[ $search_at ];
 
 			$is_introducer = '&' === $haystack[ $haystack_at ];


### PR DESCRIPTION
See https://github.com/WordPress/wordpress-develop/pull/6387/files#r1618846517 and https://github.com/WordPress/wordpress-develop/pull/5373#discussion_r1606722740.

There's reason to believe that `strcasecmp( $s[ $index ], $t[ $index ] )` is more performant than string transformations `strtoupper( $s[ $index ] ) === strtoupper( $t[ $index ] )`. Let's use that.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
