### PR TITLE
HTML API: Active format reconstruction with noah's ark

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-active-formatting-elements.php
+++ b/src/wp-includes/html-api/class-wp-html-active-formatting-elements.php
@@ -144,11 +144,7 @@ class WP_HTML_Active_Formatting_Elements {
 		 */
 		$count = 0;
 		foreach ( $this->walk_up_until_marker() as $item ) {
-			if (
-				$item->namespace === $afe->namespace &&
-				$item->tag_name === $afe->tag_name &&
-				$item->attributes === $afe->attributes
-			) {
+			if ( $item->is_equivalent( $afe ) ) {
 				if ( ++$count >= 3 ) {
 					return;
 				}
@@ -293,6 +289,23 @@ class AFE_Element {
 	public $attributes;
 	/** @var WP_HTML_Token */
 	public $token;
+
+	public function is_equivalent( self $afe ): bool {
+		if (
+			$this->namespace !== $afe->namespace ||
+			$this->tag_name !== $afe->tag_name ||
+			count( $this->attributes ) !== count( $afe->attributes )
+		) {
+			return false;
+		}
+
+		foreach ( $this->attributes as $name => $value ) {
+			if ( ! array_key_exists( $name, $afe->attributes ) || $value !== $afe->attributes[ $name ] ) {
+				return false;
+			}
+		}
+		return true;
+	}
 
 	public function __construct( string $tag_namespace, string $tag_name, array $attributes, WP_HTML_Token $token ) {
 		$this->namespace  = $tag_namespace;

--- a/src/wp-includes/html-api/class-wp-html-active-formatting-elements.php
+++ b/src/wp-includes/html-api/class-wp-html-active-formatting-elements.php
@@ -39,7 +39,7 @@ class WP_HTML_Active_Formatting_Elements {
 	 *
 	 * @since 6.4.0
 	 *
-	 * @var WP_HTML_Token[]
+	 * @var Array<AFE_Element|AFE_Marker>
 	 */
 	private $stack = array();
 
@@ -53,9 +53,9 @@ class WP_HTML_Active_Formatting_Elements {
 	 * @access private
 	 *
 	 * @param int $index Number of nodes from the top node to return.
-	 * @return WP_HTML_Token|null Node at the given index in the stack, if one exists, otherwise null.
+	 * @return AFE_Element|AFE_Marker|null Node at the given index in the stack, if one exists, otherwise null.
 	 */
-	public function at( $nth ) {
+	public function at( $nth ): AFE_Element|AFE_Marker|null {
 		return $this->stack[ $nth - 1 ];
 	}
 
@@ -67,9 +67,9 @@ class WP_HTML_Active_Formatting_Elements {
 	 * @param WP_HTML_Token $token Look for this node in the stack.
 	 * @return bool Whether the referenced node is in the stack of active formatting elements.
 	 */
-	public function contains_node( WP_HTML_Token $token ) {
+	public function contains_node( WP_HTML_Token $token ): bool {
 		foreach ( $this->walk_up() as $item ) {
-			if ( $token->bookmark_name === $item->bookmark_name ) {
+			if ( $item instanceof AFE_Element && $token->bookmark_name === $item->token->bookmark_name ) {
 				return true;
 			}
 		}
@@ -103,7 +103,7 @@ class WP_HTML_Active_Formatting_Elements {
 	}
 
 	/**
-	 * Inserts a "marker" at the end of the list of active formatting elements.
+	 * Inserts a marker at the end of the list of active formatting elements.
 	 *
 	 * > The markers are inserted when entering applet, object, marquee,
 	 * > template, td, th, and caption elements, and are used to prevent
@@ -115,7 +115,7 @@ class WP_HTML_Active_Formatting_Elements {
 	 * @since 6.7.0
 	 */
 	public function insert_marker(): void {
-		$this->push( new WP_HTML_Token( null, 'marker', false ) );
+		$this->push( new AFE_Marker() );
 	}
 
 	/**
@@ -125,9 +125,9 @@ class WP_HTML_Active_Formatting_Elements {
 	 *
 	 * @see https://html.spec.whatwg.org/#push-onto-the-list-of-active-formatting-elements
 	 *
-	 * @param WP_HTML_Token $token Push this node onto the stack.
+	 * @param AFE_Element|AFE_Marker $token Push this node onto the stack.
 	 */
-	public function push( WP_HTML_Token $token ) {
+	public function push( AFE_Element|AFE_Marker $afe ): void {
 		/*
 		 * > If there are already three elements in the list of active formatting elements after the last marker,
 		 * > if any, or anywhere in the list if there are no markers, that have the same tag name, namespace, and
@@ -139,8 +139,7 @@ class WP_HTML_Active_Formatting_Elements {
 		 *
 		 * @todo Implement the "Noah's Ark clause" to only add up to three of any given kind of formatting elements to the stack.
 		 */
-		// > Add element to the list of active formatting elements.
-		$this->stack[] = $token;
+		$this->stack[] = $afe;
 	}
 
 	/**
@@ -148,12 +147,12 @@ class WP_HTML_Active_Formatting_Elements {
 	 *
 	 * @since 6.4.0
 	 *
-	 * @param WP_HTML_Token $token Remove this node from the stack, if it's there already.
+	 * @param AFE_Element|AFE_Marker $node Remove this node from the stack, if it's there already.
 	 * @return bool Whether the node was found and removed from the stack of active formatting elements.
 	 */
-	public function remove_node( WP_HTML_Token $token ) {
+	public function remove_node( AFE_Element $node ) {
 		foreach ( $this->walk_up() as $position_from_end => $item ) {
-			if ( $token->bookmark_name !== $item->bookmark_name ) {
+			if ( $item instanceof AFE_Element && $node->token->bookmark_name !== $item->token->bookmark_name ) {
 				continue;
 			}
 
@@ -237,9 +236,28 @@ class WP_HTML_Active_Formatting_Elements {
 	public function clear_up_to_last_marker(): void {
 		foreach ( $this->walk_up() as $item ) {
 			array_pop( $this->stack );
-			if ( 'marker' === $item->node_name ) {
+			if ( $item instanceof AFE_Marker ) {
 				break;
 			}
 		}
+	}
+}
+
+class AFE_Marker {}
+class AFE_Element {
+	/** @var string */
+	public $namespace;
+	/** @var string */
+	public $tag_name;
+	/** @var array<string, string|bool|null> */
+	public $attributes;
+	/** @var WP_HTML_Token */
+	public $token;
+
+	public function __construct( string $tag_namespace, string $tag_name, array $attributes, WP_HTML_Token $token ) {
+		$this->namespace  = $tag_namespace;
+		$this->tag_name   = $tag_name;
+		$this->attributes = $attributes;
+		$this->token      = $token;
 	}
 }

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -2415,6 +2415,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '-EM':
 			case '-FONT':
 			case '-I':
+			case '-NOBR':
 			case '-S':
 			case '-SMALL':
 			case '-STRIKE':

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -5451,6 +5451,9 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		 * >    element entry was created, to obtain new element.
 		 */
 		create:
+		if ( array() !== $entry->attributes ) {
+			$this->bail( 'Cannot create active formatting elements with attributes.' );
+		}
 		$this->insert_html_element( $entry->token );
 
 		/*
@@ -6223,6 +6226,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		foreach ( $proc->get_attribute_names_with_prefix( '' ) as $name ) {
 			$attributes[ $name ] = $proc->get_attribute( $name );
 		}
+		sort( $attributes );
 		$afe = new AFE_Element(
 			$token->namespace,
 			$token->node_name,

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -2357,8 +2357,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 						case 'A':
 							$this->run_adoption_agency_algorithm();
 							$this->state->active_formatting_elements->remove_node( $item );
-							$this->state->stack_of_open_elements->remove_node( $item );
-							break;
+							$this->state->stack_of_open_elements->remove_node( $item->token );
+							break 2;
 					}
 				}
 

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -6227,7 +6227,6 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		foreach ( $proc->get_attribute_names_with_prefix( '' ) as $name ) {
 			$attributes[ $name ] = $proc->get_attribute( $name );
 		}
-		sort( $attributes );
 		$afe = new AFE_Element(
 			$token->namespace,
 			$token->node_name,

--- a/src/wp-includes/html-api/class-wp-html-token.php
+++ b/src/wp-includes/html-api/class-wp-html-token.php
@@ -31,7 +31,7 @@ class WP_HTML_Token {
 	 *
 	 * @var string
 	 */
-	public $bookmark_name = null;
+	public $bookmark_name;
 
 	/**
 	 * Name of node; lowercase names such as "marker" are not HTML elements.
@@ -90,13 +90,13 @@ class WP_HTML_Token {
 	 *
 	 * @since 6.4.0
 	 *
-	 * @param string|null   $bookmark_name         Name of bookmark corresponding to location in HTML where token is found,
+	 * @param string        $bookmark_name         Name of bookmark corresponding to location in HTML where token is found,
 	 *                                             or `null` for markers and nodes without a bookmark.
 	 * @param string        $node_name             Name of node token represents; if uppercase, an HTML element; if lowercase, a special value like "marker".
 	 * @param bool          $has_self_closing_flag Whether the source token contains the self-closing flag, regardless of whether it's valid.
 	 * @param callable|null $on_destroy            Optional. Function to call when destroying token, useful for releasing the bookmark.
 	 */
-	public function __construct( ?string $bookmark_name, string $node_name, bool $has_self_closing_flag, ?callable $on_destroy = null ) {
+	public function __construct( string $bookmark_name, string $node_name, bool $has_self_closing_flag, ?callable $on_destroy = null ) {
 		$this->bookmark_name         = $bookmark_name;
 		$this->namespace             = 'html';
 		$this->node_name             = $node_name;


### PR DESCRIPTION
# WORK IN PROGRESS

Implement Noah's Ark when pushing to the stack of active formatting elements.

> If there are already three elements in the [list of active formatting elements](https://html.spec.whatwg.org/#list-of-active-formatting-elements) after the last [marker](https://html.spec.whatwg.org/#concept-parser-marker), if any, or anywhere in the list if there are no [markers](https://html.spec.whatwg.org/#concept-parser-marker), that have the same tag name, namespace, and attributes as element, then remove the earliest such element from the [list of active formatting elements](https://html.spec.whatwg.org/#list-of-active-formatting-elements). For these purposes, the attributes must be compared as they were when the elements were created by the parser; two elements have the same attributes if all their parsed attributes can be paired such that the two attributes in each pair have identical names, namespaces, and values (the order of the attributes does not matter).

TODO:
- [ ] When adding the equivalent element, the earliest should be removed (not skip the 4th). For practical purposes in the HTML API, this may be irrelevant and can be ignored.
- [ ] Are the performance characteristics of this acceptable?
- [ ] Fix all the lints and improve the new classes and constructors.

```diff
 FAILURES!
-Tests: 1494, Assertions: 1076, Failures: 2, Skipped: 418.
+Tests: 1494, Assertions: 1097, Failures: 2, Skipped: 397.
```

Builds on https://github.com/WordPress/wordpress-develop/pull/6982.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
