### PR TITLE
Add tests to filename space separator sanitization

### DIFF
--- a/tests/phpunit/tests/formatting/sanitizeFileName.php
+++ b/tests/phpunit/tests/formatting/sanitizeFileName.php
@@ -35,13 +35,17 @@ class Tests_Formatting_SanitizeFileName extends WP_UnitTestCase {
 	 * Test that spaces are correctly replaced with dashes.
 	 *
 	 * @ticket 16330
+	 * @ticket 62995
 	 */
 	public function test_replaces_spaces() {
 		$urls = array(
-			'unencoded space.png'  => 'unencoded-space.png',
-			'encoded-space.jpg'    => 'encoded-space.jpg',
-			'plus+space.jpg'       => 'plusspace.jpg',
-			'multi %20 +space.png' => 'multi-20-space.png',
+			'unencoded space.png'                         => 'unencoded-space.png',
+			'encoded-space.jpg'                           => 'encoded-space.jpg',
+			'plus+space.jpg'                              => 'plusspace.jpg',
+			'multi %20 +space.png'                        => 'multi-20-space.png',
+			"Screenshot 2025-02-19 at 2.17.33\u{202F}PM.png" => 'Screenshot-2025-02-19-at-2.17.33-PM.png',
+			"Filename with non-breaking\u{00A0}space.txt" => 'Filename-with-non-breaking-space.txt',
+			"Filename with thin\u{2009}space.txt"         => 'Filename-with-thin-space.txt',
 		);
 
 		foreach ( $urls as $test => $expected ) {


### PR DESCRIPTION
Add some tests for https://github.com/WordPress/wordpress-develop/pull/9103.

```sh
# from repo checkout
./vendor/bin/phpunit --testdox --group=16330
```

```diff
-OK (1 test, 4 assertions)
+OK (1 test, 7 assertions)
```

If I revert `wp-includes/formatting.php` to `trunk`'s version, the tests fail:

```
_Formatting_Sanitize File Name
 ✘ Replaces spaces
   ┐
   ├ Failed asserting that two strings are identical.
   ┊ ---·Expected
   ┊ +++·Actual
   ┊ @@ @@
   ┊ -'Screenshot-2025-02-19-at-2.17.33-PM.png'
   ┊ +'Screenshot-2025-02-19-at-2.17.33 PM.png'
   │
   ╵ …/tests/phpunit/tests/formatting/sanitizeFileName.php:52
   ┴
```

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
